### PR TITLE
Add a tooltip for the column "Num GPUs" when the job runs on MIG(Multi-Instance GPU) devices

### DIFF
--- a/cacti/plugins/grid/lib/grid_functions.php
+++ b/cacti/plugins/grid/lib/grid_functions.php
@@ -15169,6 +15169,7 @@ function build_job_display_array($jobs_page = '') {
 		),
 		'num_gpus' => array(
 			'display' => __('Num GPUs', 'grid'),
+			'tip' => __('If this job is running on an NVIDIA MIG (Multi-Instance GPU), shows the number of MIG devices.', 'grid'),
 			'dbname'  => 'show_gpus',
 			'align'	  => 'right',
 			'sort'    => 'DESC'


### PR DESCRIPTION
When a job runs on MIG GPU, the column "Num GPUs" is for the number of MIG devices.