### PR TITLE
Calculation of user efficiency for queue / LSF host group names not URL encoded

### DIFF
--- a/cacti/plugins/grid/grid_bhgroups.php
+++ b/cacti/plugins/grid/grid_bhgroups.php
@@ -573,6 +573,8 @@ function grid_view_bhg() {
 
 			form_alternate_row();
 
+			$groupName = urlencode($groupName);
+
                         $action_url = "<a class='pic' href='". html_escape($config['url_path'] . 'plugins/grid/grid_bhosts.php' .
                                 '?reset=1' .
                                 '&clusterid=' . $bhg['clusterid'] .

--- a/cacti/plugins/grid/lib/grid_functions.php
+++ b/cacti/plugins/grid/lib/grid_functions.php
@@ -5326,7 +5326,7 @@ function move_records_into_finished_table() {
 			SUM(CASE WHEN stat IN ('PEND', 'PSUSP') THEN maxNumProcessors ELSE 0 END) AS 'pendjobs',
 			SUM(CASE WHEN stat IN ('RUNNING','PROV') THEN num_cpus ELSE 0 END) AS 'runjobs',
 			SUM(CASE WHEN stat IN ('SSUSP', 'USUSP') THEN num_cpus ELSE 0 END) AS 'suspjobs',
-			AVG(CASE WHEN stat='RUNNING' THEN efficiency ELSE 0 END) AS 'efficiency',
+			AVG(CASE WHEN stat='RUNNING' THEN efficiency ELSE NULL END) AS 'efficiency',
 			'1' as present
 			FROM grid_jobs
 			WHERE job_end_logged=0


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to IBM Spectrum LSF RTM! There are a few simple things to check before submitting your pull request that can help with the review process. You should delete these items from your submission, but they are here to help bring them to your
attention.
-->
<!-- If this pull request resolves any bugs in the issues, provide a link: -->
**Issue1:** Correct the existing calculation of user efficiency for queue which pending jobs are taken into account incorrectly.
platformcomputing/lsf-addon-L3-tracker#590

**Issue2:** LSF host group names includes & but not URL encoded properly.
platformcomputing/lsf-addon-L3-tracker#589

<!--
Have you followed the [contributor guidelines](https://github.com/IBM/ibm-spectrum-lsf-rtm-server/blob/main/CONTRIBUTING.md)?
Thank you for your contribution to IBM Spectrum LSF RTM!
-->