### PR TITLE
Fix the time format display for benchmark jobs

### DIFF
--- a/cacti/plugins/benchmark/functions.php
+++ b/cacti/plugins/benchmark/functions.php
@@ -64,7 +64,7 @@ function benchmark_status_filter($location = 'summary') {
 }
 
 function benchmark_get_time($value) {
-	return __('%.2f sec', number_format(round($value,2),2));
+	return __('%s sec', number_format_i18n($value, 2));
 }
 
 function benchmark_get_exit_code($status, $reason) {


### PR DESCRIPTION
After Cacti upgrades to v1.2.26, some time fields of the benchmark jobs are not displayed correctly.

To Reproduce

    Install RTM 10.2.0.15 daily build package
    Create a benchmark job

Check the below pages:

    /cacti/plugins/benchmark/grid_benchmark_summary.php
    /cacti/plugins/benchmark/grid_benchmark_jobs.php

This PR fixes the issue.

<!--
Thank you for your interest in and contributing to IBM Spectrum LSF RTM! There are a few simple things to check before submitting your pull request that can help with the review process. You should delete these items from your submission, but they are here to help bring them to your
attention.
-->
<!-- If this pull request resolves any bugs in the issues, provide a link: -->

<!--
Have you followed the [contributor guidelines](https://github.com/IBM/ibm-spectrum-lsf-rtm-server/blob/main/CONTRIBUTING.md)?
Thank you for your contribution to IBM Spectrum LSF RTM!
-->