### PR TITLE
Rollback cacti csrf_secret.php path to fix the CSRF error after Cacti upgrade

### DIFF
--- a/cacti/include/config.php
+++ b/cacti/include/config.php
@@ -127,7 +127,7 @@ $disable_log_rotation = false;
  * the CRSF secret file.
  */
 
-//$path_csrf_secret = '/usr/share/cacti/resource/csrf-secret.php';
+$path_csrf_secret = '/opt/IBM/rtm/etc/csrf-secret.php';
 
 /**
  * The following are optional variables for debugging low level system


### PR DESCRIPTION
Fix the CSRF issue after cacti upgrade:

```
ERROR PHP WARNING: fopen(/opt/IBM/cacti/include/vendor/csrf/csrf-secret.php): Failed to open stream: Permission denied in file: /opt/IBM/cacti/include/vendor/csrf/csrf-magic.php  on line: 491
CMDPHP PHP ERROR WARNING Backtrace:  (/logout.php[39]:api_plugin_hook_function(), /lib/plugins.php[151]:api_plugin_run_plugin_hook_function(), /lib/plugins.php[272]:rtm_custom_logout(), /plugins/RTM/include/logout.php[76]:unknown(), /include/global_session.php[143]:csrf_get_tokens(), /include/vendor/csrf/csrf-magic.php[126]:csrf_get_secret(), /include/vendor/csrf/csrf-magic.php[367]:csrf_writable(), /include/vendor/csrf/csrf-magic.php[491]:fopen(), CactiErrorHandler())
```