### PR TITLE
Check if the variable is null befere passing it to strlen

### DIFF
--- a/cacti/plugins/grid/lib/grid_functions.php
+++ b/cacti/plugins/grid/lib/grid_functions.php
@@ -12458,7 +12458,8 @@ function create_pending_filter_sqlwhere_ignore() {
 
 	$job_pend_ignore_regexp = read_grid_config_option('general_pending_ignore', true);
 
-	if (strlen($job_pend_ignore_regexp) > 0) {
+	if (isset($job_pend_ignore_regexp) &&
+		strlen($job_pend_ignore_regexp) > 0) {
 		if (strlen($job_pend_proc_sqlwhere_ignore) > 0) {
 			$job_pend_proc_sqlwhere_ignore .= " AND ";
 		}


### PR DESCRIPTION
Fix the problem with the new version of PHP:

```
strlen(): Passing null to parameter #1 ($string) of type string is deprecated in file: cacti/plugins/grid/lib/grid_functions.php on line: 12462 
```

<!--
Thank you for your interest in and contributing to IBM Spectrum LSF RTM! There are a few simple things to check before submitting your pull request that can help with the review process. You should delete these items from your submission, but they are here to help bring them to your
attention.
-->
<!-- If this pull request resolves any bugs in the issues, provide a link: -->
<!--
Have you followed the [contributor guidelines](https://github.com/IBM/ibm-spectrum-lsf-rtm-server/blob/main/CONTRIBUTING.md)?
Thank you for your contribution to IBM Spectrum LSF RTM!
-->