### PR TITLE
QA: Issues when the graph can not be found

### DIFF
--- a/cacti/lib/html.php
+++ b/cacti/lib/html.php
@@ -304,12 +304,17 @@ function html_graph_area(&$graph_array, $no_graphs_message = '', $extra_url_args
 
 		foreach ($graph_array as $graph) {
 			if (!isset($graph['host_id'])) {
-				list($graph['host_id'], $graph['disabled']) = db_fetch_row_prepared('SELECT host_id, disabled
-    					FROM graph_local AS gl
-	 				LEFT JOIN host AS h
+				$graph_data = db_fetch_row_prepared('SELECT host_id, disabled
+					FROM graph_local AS gl
+					LEFT JOIN host AS h
 					ON gl.host_id = h.id
-     					WHERE gl.id = ?',
+					WHERE gl.id = ?',
 					array($graph['local_graph_id']));
+
+				if (cacti_sizeof($graph_data)) {
+					$graph['host_id']  = $graph_data['host_id'];
+					$graph['disabled'] = $graph_data['disabled'];
+				}
 			}
 
 			if ($i == 0) {


### PR DESCRIPTION
This pull request resolves an issue where if for some reason, the local graph ID does not exist, errors are thrown in the cacti.log file about unset array keys.

In most cases this will not happen, but it can happen from time to time.

signed-off: thewitness@cacti.net