### PR TITLE
Publishing the gridlimits plugin

### DIFF
--- a/cacti/plugins/gridlimits/INFO
+++ b/cacti/plugins/gridlimits/INFO
@@ -1,0 +1,10 @@
+[info]
+name = gridlimits
+version = 10.2.0.16
+longname = IBM Spectrum LSF RTM Limits Plugin
+author = IBM Corporation
+email = 
+homepage = http://www.ibm.com
+compat = 1.2.24
+requires = grid RTM
+capabilities = online_view:1, online_mgmt:1, offline_view:0, offline_mgmt:0, remote_collect:0

--- a/cacti/plugins/gridlimits/README.md
+++ b/cacti/plugins/gridlimits/README.md
@@ -1,0 +1,50 @@
+# gridlimits
+
+The gridlimits plugin allows viewing of LSF limits usage for a variety
+of LSF limits cases.  It allows the users of the gridlimits plugin
+to view limits by user, group, queue, etc. over upto a two week period.
+
+It uses FusionCharts that are included in the RTM product to render 
+visually pleasant charts which makes them more easily presentable.
+
+## Core Features
+
+* View Limits Use for all LSF Cluster
+
+* View Graphs of Limits Usage for Upto Two Weeks
+
+## Limitations
+
+* Does not support Global Limits at this time.
+
+* Limits by Application Profile, though collected, are not displayed.
+
+## Installation
+
+To install the gridlimits plugin, follow the steps below:
+
+1. Goto the RTM console and install and enable the plguin.  This
+   step will create the base tables required by the data collector.
+
+2. Copy the binary file in the bin plguin directory to the various 
+   RTM data collector directories.  The default location for the RTM 
+   data collectors is /opt/IBM/rtm/lsf*/bin.
+
+3. Users with 'General LSF Data' permission will automatically be
+   able to view the Limits data under the Cluster top tab under
+   Reports > Limits page.
+
+4. Review the Cacti log for errors.  If you find errors report them
+   to IBM or submit a pull request to make updates.
+
+## Possible Bugs and Feature Enhancements
+
+Bug and feature enhancements for the gridlimits plugin are handled in GitHub
+or through your contract with IBM. If you find a bug, reach out to IBM and
+open a ticket or alternatively, open a pull request on GitHub.
+
+## Authors
+
+The gridlimits plugin was initially developed by Sean McCombe several years
+ago.  It has been enhanced recently by Larry Adams (aka TheWitness).
+

--- a/cacti/plugins/gridlimits/bin/index.php
+++ b/cacti/plugins/gridlimits/bin/index.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright IBM Corp. 2006, 2025                                          |
+ |                                                                         |
+ | Licensed under the Apache License, Version 2.0 (the "License");         |
+ | you may not use this file except in compliance with the License.        |
+ | You may obtain a copy of the License at                                 |
+ |                                                                         |
+ | http://www.apache.org/licenses/LICENSE-2.0                              |
+ |                                                                         |
+ | Unless required by applicable law or agreed to in writing, software     |
+ | distributed under the License is distributed on an "AS IS" BASIS,       |
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.|
+ | See the License for the specific language governing permissions and     |
+ | limitations under the License.                                          |
+ +-------------------------------------------------------------------------+
+*/
+
+header('Location:../index.php');
+

--- a/cacti/plugins/gridlimits/functions.php
+++ b/cacti/plugins/gridlimits/functions.php
@@ -1,0 +1,118 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright IBM Corp. 2006, 2025                                          |
+ |                                                                         |
+ | Licensed under the Apache License, Version 2.0 (the "License");         |
+ | you may not use this file except in compliance with the License.        |
+ | You may obtain a copy of the License at                                 |
+ |                                                                         |
+ | http://www.apache.org/licenses/LICENSE-2.0                              |
+ |                                                                         |
+ | Unless required by applicable law or agreed to in writing, software     |
+ | distributed under the License is distributed on an "AS IS" BASIS,       |
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.|
+ | See the License for the specific language governing permissions and     |
+ | limitations under the License.                                          |
+ +-------------------------------------------------------------------------+
+*/
+
+/**
+ * Get table partitions in the database for a query
+ *
+ * @param $sql_query The SQL query to be updated with the partitions involved in the query
+ * @param $table_name The table name to be updated with the partitions involved
+ * @param $sql_where The sql_where to include in each partition selected
+ * @param $date1 The state date of the period
+ * @param $date2 The end date of the period
+ *
+ * @return The updated query
+ */
+function get_records_partition($sql_query, $table_name, $sql_where, $date1, $date2, $params) {
+	$output = array();
+
+	$tables = partition_get_partitions_for_query($table_name, $date1, $date2);
+
+	foreach ($tables as $table) {
+		$query_replaced = str_replace($table_name, $table, $sql_query);
+
+		$records = db_fetch_assoc_prepared($query_replaced, $params);
+		$output  = array_unique(array_merge($output,$records), SORT_REGULAR);
+	}
+
+	return $output;
+}
+
+
+/**
+ * Generates SQL query that pulls data from multiple partitions in the database
+ *
+ * @param $sql_query The SQL query to be updated with the partitions involved in the query
+ * @param $table_name The table name to be updated with the partitions involved
+ * @param $sql_where The sql_where to include in each partition selected
+ * @param $date1 The state date of the period
+ * @param $date2 The end date of the period
+ * @param $params For prepared statements
+ * @param $all Boolean to use UNION ALL vs UNION
+ *
+ * @return The updated SQL query, with $table_name replaced in $sql_query with the relevant partitions
+ */
+function generate_partition_union_query($sql_query, $table_name, $sql_where, $date1, $date2, $params = array(), $all = true) {
+	$return = array(
+		'params' => array(),
+		'sql'    => ''
+	);
+
+	$tables = partition_get_partitions_for_query($table_name, $date1, $date2);
+
+	foreach ($tables as $table) {
+		$query_replaced = '(' . str_replace($table_name, $table, $sql_query);
+
+		$return['sql'] .= ($return['sql'] == '' ? '':($all ? ' UNION ALL ':' UNION ')) . $query_replaced . ' ' . $sql_where . ')';
+
+		if (cacti_sizeof($params)) {
+			foreach($params as $p) {
+				$return['params'][] = $p;
+			}
+		}
+	}
+
+	return $return;
+}
+
+function sql_param_debug($sql, $params) {
+	if (cacti_sizeof($params)) {
+		$sql = str_replace('?', '"%s"', $sql);
+		$format_cnt = substr_count($sql, '%s');
+		$param_cnt  = cacti_sizeof($params);
+		cacti_log('FormatCNT: ' . $format_cnt . ', ParamCNT: ' . $param_cnt, false);
+		cacti_log('SQL: ' . $sql, false);
+		cacti_log('PARAMS: ' . implode(', ', $params), false);
+		cacti_log('WITH PARAMS: ' . vsprintf($sql, $params), false);
+	} else {
+		cacti_log('NO PARAMS: ' . $sql, false);
+	}
+}
+
+function get_limit_type($sequenceid) {
+	$row = db_fetch_row_prepared('SELECT *
+		FROM grid_limits_history
+		WHERE sequenceid = ?',
+		array($sequenceid));
+
+	if ($row['slots_usage'] > 0 || $row['slots_limit'] > 0) {
+		return 'slots';
+	} elseif ($row['mem_usage'] > 0 || $row['mem_limit'] > 0) {
+		return 'mem';
+	} elseif ($row['swp_usage'] > 0 || $row['swp_limit'] > 0) {
+		return 'swp';
+	} elseif ($row['tmp_usage'] > 0 || $row['tmp_limit'] > 0) {
+		return 'tmp';
+	} elseif ($row['jobs_usage'] > 0 || $row['jobs_limit'] > 0) {
+		return 'jobs';
+	} elseif ($row['fwd_tasks_usage'] > 0 || $row['fwd_tasks_limit'] > 0) {
+		return 'fwd_tasks';
+	} else {
+		return $row['resources'];
+	}
+}

--- a/cacti/plugins/gridlimits/grid_limits.php
+++ b/cacti/plugins/gridlimits/grid_limits.php
@@ -1,0 +1,1793 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright IBM Corp. 2006, 2025                                          |
+ |                                                                         |
+ | Licensed under the Apache License, Version 2.0 (the "License");         |
+ | you may not use this file except in compliance with the License.        |
+ | You may obtain a copy of the License at                                 |
+ |                                                                         |
+ | http://www.apache.org/licenses/LICENSE-2.0                              |
+ |                                                                         |
+ | Unless required by applicable law or agreed to in writing, software     |
+ | distributed under the License is distributed on an "AS IS" BASIS,       |
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.|
+ | See the License for the specific language governing permissions and     |
+ | limitations under the License.                                          |
+ +-------------------------------------------------------------------------+
+*/
+
+$guest_account = true;
+chdir('../../');
+include('./include/auth.php');
+include_once('./plugins/grid/lib/grid_filter_functions.php');
+include_once('./plugins/grid/lib/grid_partitioning.php');
+include_once('./plugins/gridlimits/functions.php');
+
+$title = __('LSF Limits', 'gridlimits');
+
+set_default_action('limits');
+
+switch(get_request_var('action')) {
+	case 'limits':
+		drawLimitsTable();
+
+		break;
+	case 'usage':
+		drawUsePage();
+
+		break;
+	default:
+		drawChartAjax();
+}
+
+function drawChartAjax() {
+	validateUseVariables();
+
+	if (isset_request_var('sequenceid')) {
+		$sequenceid = get_filter_request_var('sequenceid');
+	} else {
+		return;
+	}
+
+	if (isset_request_var('action')) {
+		$action = get_request_var('action');
+
+		if ($action == 'getChartCount') {
+			$count = 0;
+
+			$row = db_fetch_row_prepared('SELECT *
+				FROM grid_limits_history
+				WHERE sequenceid = ?',
+				array($sequenceid));
+
+			$result = '';
+
+			$strings = array(
+				'slots_usage',
+				'mem_usage',
+				'swp_usage',
+				'tmp_usage',
+				'jobs_usage',
+				'resources',
+				'fwd_tasks_usage'
+			);
+
+			foreach ($strings as $string) {
+				if ($string != 'resources') {
+					if ($row[$string] != 0) {
+						if ($result != '') {
+							$result .= ",\"" . $string . "\": \"Y\"\n";
+						} else {
+							$result .= "\"" . $string . "\": \"Y\"\n";
+						}
+					}
+				} elseif ($row[$string] != NULL && $row[$string] != '') {
+					$arr = preg_split('/\s+/', trim($row[$string]));
+
+					$i = 0;
+					foreach ($arr as $a) {
+						$i++;
+						if ($i % 2 != 0) {
+							if ($result != '') {
+								$result .= ",\"" . $a . "\": \"Y\"\n";
+							} else {
+								$result .= "\"" . $a . "\": \"Y\"\n";
+							}
+						}
+					}
+				}
+			}
+
+			$result = '{' . $result . '}';
+
+			print($result);
+		} else if ($action == 'getData') {
+			$newcat     = array();
+			$newseries1 = array();
+			$newseries2 = array();
+
+			if (isset_request_var('resource') && strpos(get_nfilter_request_var('resource'), '_usage') == false) {
+				$resource = get_nfilter_request_var('resource');
+			} else {
+				$resource = get_limit_type($sequenceid);
+			}
+
+			$row = db_fetch_row_prepared('SELECT *
+				FROM grid_limits_history
+				WHERE sequenceid = ?',
+				array($sequenceid));
+
+			$clusterid    = $row['clusterid'];
+			$limit_name   = $row['limit_name'];
+			$users        = $row['users'];
+			$queues       = $row['queues'];
+			$hosts        = $row['hosts'];
+			$projects     = $row['projects'];
+			$lic_projects = $row['lic_projects'];
+			$clusters     = $row['clusters'];
+
+			$time_period  = get_filter_request_var('time_period');
+			$now          = time();
+
+			$where = '';
+			switch ($_REQUEST['time_period']) {
+				case 1:
+					$where .= ' AND (last_updated > DATE_SUB(now(), INTERVAL 2 hour)) ';
+					$start  = date('Y-m-d H:i:s', $now - (3600 * 2));
+					break;
+				case 2:
+					$where .= ' AND (last_updated > DATE_SUB(now(), INTERVAL 6 hour)) ';
+					$start  = date('Y-m-d H:i:s', $now - (3600 * 6));
+					break;
+				case 3:
+					$where .= ' AND (last_updated > DATE_SUB(now(), INTERVAL 12 hour)) ';
+					$start  = date('Y-m-d H:i:s', $now - (3600 * 12));
+					break;
+				case 4:
+					$where .= ' AND (last_updated > DATE_SUB(now(), INTERVAL 24 hour)) ';
+					$start  = date('Y-m-d H:i:s', $now - 86400);
+					break;
+				case 5:
+					$where .= ' AND (last_updated > DATE_SUB(now(), INTERVAL 2 day)) ';
+					$start  = date('Y-m-d H:i:s', $now - (86400 * 2));
+					break;
+				case 6:
+					$where .= ' AND (last_updated > DATE_SUB(now(), INTERVAL 7 day)) ';
+					$start  = date('Y-m-d H:i:s', $now - (86400 * 7));
+					break;
+				case 7:
+					$where .= ' AND (last_updated > DATE_SUB(now(), INTERVAL 14 day)) ';
+					$start  = date('Y-m-d H:i:s', $now - (86400 * 14));
+					break;
+			}
+
+			$resource_types = array(
+				'slots',
+				'mem',
+				'swp',
+				'tmp',
+				'jobs',
+				'fwd_tasks'
+			);
+
+			$params = array(
+				$clusterid,
+				$limit_name,
+				$users,
+				$queues,
+				$hosts,
+				$projects,
+				$lic_projects,
+				$clusters
+			);
+
+			if (in_array($resource, $resource_types)) {
+				$sql = 'SELECT limit_name, users, last_updated,
+					last_updated as last_updated2,
+					' . $resource . '_usage AS col1,
+					' . $resource . '_limit as col2
+					FROM grid_limits_usage
+					WHERE clusterid = ?
+					AND limit_name = ?
+					AND users = ?
+					AND queues = ?
+					AND hosts = ?
+					AND projects = ?
+					AND lic_projects = ?
+					AND clusters = ?';
+			} else {
+				$usage = "SUBSTRING_INDEX(SUBSTRING_INDEX(LTRIM(SUBSTRING_INDEX(resources, '$resource', -1)), ' ', 1), '/', 1)";
+				$limit = "SUBSTRING_INDEX(SUBSTRING_INDEX(LTRIM(SUBSTRING_INDEX(resources, '$resource', -1)), ' ', 1), '/', -1)";
+
+				$sql = 'SELECT limit_name, users, last_updated,
+					last_updated as last_updated2,
+					' . $usage . ' AS col1,
+					' . $limit . ' as col2
+					FROM grid_limits_usage
+					WHERE clusterid = ?
+					AND limit_name = ?
+					AND users = ?
+					AND queues = ?
+					AND hosts = ?
+					AND projects = ?
+					AND lic_projects = ?
+					AND clusters = ?';
+			}
+
+			$sql  = $sql;
+			$end  = date('Y-m-d H:i:s');
+
+			$return = generate_partition_union_query($sql, 'grid_limits_usage', $where, $start, $end, $params);
+
+			$return['sql'] .= ' ORDER BY last_updated2 ASC';
+
+			//sql_param_debug($return['sql'], $return['params']);
+
+			$rows = db_fetch_assoc_prepared($return['sql'], $return['params']);
+
+			$series1 = '';
+			$series2 = '';
+
+			if (cacti_sizeof($rows)) {
+				foreach ($rows as $row) {
+					if ($series1 == '') {
+						$series1 .= "{\n";
+					} else {
+						$series1 .= ",{\n";
+					}
+
+					if ($series2 == '') {
+						$series2 .= "{\n";
+					} else {
+						$series2 .= ",{\n";
+					}
+
+					$series1 .= "\"value\": \"" . $row['col1'] . "\"\n";
+					$series2 .= "\"value\": \"" . $row['col2'] . "\"\n";
+
+					$series1 .= "}\n";
+					$series2 .= "}\n";
+
+					$newseries1[]['value'] = $row['col1'];
+					$newseries2[]['value'] = $row['col2'];
+				}
+
+				$categories = '';
+				foreach ($rows as $row) {
+					if ($categories == '') {
+						$categories .= "{\n";
+					} else {
+						$categories .= ",{\n";
+					}
+
+					$categories .= "\"label\": \"" . substr($row['last_updated'], 5, 11) . "\"\n";
+					$categories .= "}\n";
+					$newcat[]['label'] = substr($row['last_updated'], 5, 11);
+				}
+
+				$name  = '';
+				$users = '';
+
+				foreach ($rows as $row) {
+					$name  = $row['limit_name'];
+					$users = $row['users'];
+					break;
+				}
+
+				$caption = '';
+				if ($users != '') {
+					$caption = __esc('Limit Usage - %s - %s', $limit_name, $users, 'gridlimits') . '<br/>' . $resource;
+				} else {
+					$caption = __esc('Limit Usage - %s', $limit_name, 'gridlimits') . '<br/> ' . $resource;
+				}
+
+				header('Content-Type: application/json');
+
+				$myChart = array(
+					'chart' => array(
+						'showvalues'   => '0',
+						'animation'    => '0',
+						'labelDisplay' => 'auto',
+						'yAxisName'    => __esc('Usage', 'gridlimits'),
+						'xAxisName'    => __esc('Date', 'gridlimits'),
+						'labelStep'    => '3',
+						'drawAnchors'  => '0',
+						'caption'      => $caption
+					),
+					'categories' => array(
+						array(
+							'category' => $newcat
+						)
+					),
+					'dataset' => array(
+						array(
+							'seriesname' => __esc('Usage', 'gridlimits'),
+							'data' => $newseries1
+						),
+						array(
+							'seriesname' => __esc('Limit', 'gridlimits'),
+							'data' => $newseries2
+						),
+					)
+				);
+
+				$chart = '"chart": { "showvalues": "0", "animation": "0", "labelDisplay": "auto", "yAxisName": "Usage",
+					"xAxisName": "Date", "labelStep": "3", "drawAnchors": "0", "caption": "' . $caption . '"}';
+
+				$series1    = '{ "seriesname": ' . __esc('Usage', 'gridlimits') . ', "data": [' . $series1 . '] }';
+				$series2    = '{ "seriesname": ' . __esc('Limit', 'gridlimits') . ', "data": [' . $series2 . '] }';
+				$categories = '"categories": [ { "category":  [ ' . $categories . ' ] } ]';
+				$data       = '"dataset": [ ' . $series1 . ', ' . $series2 . ']';
+				$output     = '{' . $chart . ',' . $categories . ',' . $data . '}';
+
+				//printf($output);
+				print json_encode($myChart);
+			} else {
+				return;
+			}
+		} else {
+			return;
+		}
+	} else {
+		return;
+	}
+}
+
+function drawTabs() {
+    global $config;
+
+    /* present a tabbed interface */
+    $tabs = array(
+        'limits' => __('Limits', 'gridlimits'),
+        'usage'  => __('Limit Usage', 'gridlimits'),
+    );
+
+    /* set the default tab */
+    $current_tab = get_nfilter_request_var('action');
+
+	if (empty($current_tab)) {
+		$current_tab = 'limits';
+	}
+
+    /* draw the tabs */
+    print "<div class='tabs'><nav><ul>";
+
+    if (cacti_sizeof($tabs)) {
+        foreach ($tabs as $action => $tab_name) {
+            print '<li><a class="tab pic' . (($action == $current_tab) ? ' selected"' : '"') . ' href="' . html_escape($config['url_path'] .
+                'plugins/gridlimits/grid_limits.php' .
+                '?action=' . $action) .
+                '">' . html_escape($tab_name) . '</a></li>';
+        }
+    }
+
+    print '</ul></nav></div>';
+}
+
+function drawLimitsFilter() {
+	global $config, $grid_rows_selector, $title;
+
+	html_start_box($title, '100%', '', '3', 'center', '');
+
+	$measure = get_request_var('measure');
+
+	if ($measure == '-1') {
+		$measures = get_in_use_measures(get_request_var('clusterid'));
+
+		if (sizeof($measures)) {
+			foreach($measures as $column => $name) {
+				$measure = $column;
+				set_request_var('measure', $measure);
+
+				break;
+			}
+		}
+	}
+
+	if (!isset_request_var('limit_name') || get_nfilter_request_var('limit_name') == -1) {
+		$clusters = db_fetch_assoc("SELECT gc.clusterid, gc.clustername
+			FROM grid_clusters AS gc
+			INNER JOIN (SELECT DISTINCT clusterid FROM grid_limits WHERE $measure > 0) AS gl
+			ON gc.clusterid = gl.clusterid
+			WHERE gc.disabled = ''
+			ORDER BY clustername");
+	} else {
+		$clusters = db_fetch_assoc_prepared("SELECT DISTINCT gc.clusterid, gc.clustername
+			FROM grid_clusters AS gc
+			INNER JOIN grid_limits AS gl
+			ON gc.clusterid = gl.clusterid
+			WHERE gc.disabled = ''
+			AND gl.limit_name = ?
+			AND $measure > 0
+			ORDER BY clustername",
+			array(get_nfilter_request_var('limit_name')));
+	}
+
+	$classes = array(
+		'host'        => __esc('Host', 'gridlimits'),
+		'lic_project' => __esc('License Project', 'gridlimits'),
+		'project'     => __esc('Project', 'gridlimits'),
+		'queue'       => __esc('Queue', 'gridlimits'),
+		'user'        => __esc('User', 'gridlimits'),
+	);
+
+	?>
+	<tr class='odd'>
+		<td>
+			<form id='form_limits'>
+			<table class='filterTable'>
+				<tr>
+					<td>
+						<?php print __('Cluster', 'gridlimits');?>
+					</td>
+					<td>
+						<select id='clusterid' onChange='applyFilter()'>
+							<?php
+							print '<option value="-1"' . (get_request_var('clusterid') <= 0 ? ' selected':'') . '>' . __esc('All', 'gridlimits') . '</option>';
+							if (cacti_sizeof($clusters)) {
+								foreach ($clusters as $cluster) {
+									print '<option value="' . $cluster['clusterid'] . '"' . (get_request_var('clusterid') == $cluster['clusterid'] ? ' selected':'') . '>' . html_escape($cluster['clustername']) . '</option>';
+								}
+							}
+							?>
+						</select>
+					</td>
+					<td>
+						<?php print __('Measure', 'gridlimits');?>
+					</td>
+					<td>
+						<select id='measure' onChange='applyFilter()'>
+							<?php
+							$measures = get_in_use_measures(get_request_var('clusterid'));
+
+							if (cacti_sizeof($measures)) {
+								foreach ($measures as $key => $class) {
+									print '<option value="' . $key . '"' . (get_request_var('measure') == $key ? ' selected':'') . '>' . $class . '</option>';
+								}
+							}
+							?>
+						</select>
+					</td>
+					<td>
+						<?php print __('Class', 'gridlimits');?>
+					</td>
+					<td>
+						<select id='class' onChange='applyFilter()'>
+							<?php
+							print '<option value="-1"' . (get_request_var('class') == -1 ? ' selected':'') . '>' . __esc('All', 'gridlimits') . '</option>';
+							if (cacti_sizeof($classes)) {
+								foreach ($classes as $key => $class) {
+									print '<option value="' . $key . '"' . (get_request_var('class') == $key ? ' selected':'') . '>' . $class . '</option>';
+								}
+							}
+							?>
+						</select>
+					</td>
+					<td>
+						<span>
+							<input id='go' type='submit' value='<?php print __('Go', 'gridlimits');?>'>
+							<input id='clear' type='button' value='<?php print __('Clear', 'gridlimits');?>'>
+						</span>
+					</td>
+				</tr>
+			</table>
+			<table class='filterTable'>
+				<tr>
+					<td>
+						<?php print __('Search', 'gridlimits');?>
+					</td>
+					<td>
+						<input type='text' id='filter' size='30' value='<?php print html_escape_request_var('filter');?>'>
+					</td>
+					<td>
+						<?php print __('Records', 'gridlimits');?>
+					</td>
+					<td>
+						<select id='rows' onChange='applyFilter()'>
+							<?php
+							if (cacti_sizeof($grid_rows_selector)) {
+								foreach ($grid_rows_selector as $key => $value) {
+									print '<option value="' . $key . '"' . (get_request_var('rows') == $key ? ' selected':'') . '>' . $value . '</option>';
+								}
+							}
+							?>
+						</select>
+					</td>
+				</tr>
+			</table>
+			</form>
+			<script type="text/javascript">
+
+			function applyFilter() {
+				strURL = 'grid_limits.php?header=false';
+				strURL += '&action=limits';
+				strURL += '&filter='    + $('#filter').val();
+				strURL += '&measure='   + $('#measure').val();
+				strURL += '&class='     + $('#class').val();
+				strURL += '&rows='      + $('#rows').val();
+				strURL += '&clusterid=' + $('#clusterid').val();
+				loadPageNoHeader(strURL);
+			}
+
+			function clearFilter() {
+				strURL  = 'grid_limits.php?header=false';
+				strURL += '&action=limits';
+				strURL += '&clear=true';
+				loadPageNoHeader(strURL);
+			}
+
+			$(function() {
+				$('#form_limits').submit(function(event) {
+					event.preventDefault();
+					applyFilter();
+				});
+
+				$('#clear').click(function() {
+					clearFilter();
+				});
+			});
+
+			</script>
+		</td>
+	</tr>
+
+	<?php
+
+	html_end_box();
+}
+
+function get_in_use_measures($clusterid) {
+	$measures = array(
+		'slots'      => __('Slots', 'gridlimits'),
+		'jobs'       => __('Jobs', 'gridlimits'),
+		'mem'        => __('Memory', 'gridlimits'),
+		'swp'        => __('Virtual Memory', 'gridlimits'),
+		'tmp'        => __('Tmp Use', 'gridlimits'),
+		'fwd_tasks'  => __('Forwarded Tasks', 'gridlimits'),
+		'resources'  => __('Resource', 'gridlimits')
+	);
+
+	if ($clusterid > 0) {
+		$limits = db_fetch_row_prepared('SELECT MAX(slots) AS slots,
+			MAX(jobs) AS jobs,
+			MAX(mem) AS mem,
+			MAX(swp) AS swp,
+			MAX(tmp) AS tmp,
+			MAX(fwd_tasks) AS fwd_tasks,
+			SUM(CASE WHEN resources != "" THEN 1 ELSE 0 END) AS resources
+			FROM grid_limits
+			WHERE clusterid = ?',
+			array($clusterid));
+	} else {
+		$limits = db_fetch_row_prepared('SELECT MAX(slots) AS slots,
+			MAX(jobs) AS jobs,
+			MAX(mem) AS mem,
+			MAX(swp) AS swp,
+			MAX(tmp) AS tmp,
+			MAX(fwd_tasks) AS fwd_tasks,
+			SUM(CASE WHEN resources != "" THEN 1 ELSE 0 END) AS resources
+			FROM grid_limits');
+	}
+
+	if (cacti_sizeof($limits)) {
+		foreach($measures as $key => $name) {
+			if ($limits[$key] == 0) {
+				unset($measures[$key]);
+			}
+		}
+
+		return $measures;
+	} else {
+		return array();
+	}
+}
+
+function showLimitColumn($name, $limit_name, $clusterid) {
+	static $limit_data = array();
+
+	if (isset($limit_data[$limit_name . '|' . $clusterid])) {
+		$limits = $limit_data[$limit_name . '|' . $clusterid];
+	} elseif ($clusterid > 0) {
+		$limits = db_fetch_row_prepared('SELECT
+			SUM(CASE WHEN resources != "" THEN 1 ELSE 0 END) AS resources,
+			SUM(CASE WHEN users != "" THEN 1 ELSE 0 END) AS users,
+			SUM(CASE WHEN hosts != "" THEN 1 ELSE 0 END) AS hosts,
+			SUM(CASE WHEN queues != "" THEN 1 ELSE 0 END) AS queues,
+			SUM(CASE WHEN projects != "" THEN 1 ELSE 0 END) AS projects,
+			SUM(CASE WHEN lic_projects != "" THEN 1 ELSE 0 END) AS lic_projects,
+			SUM(CASE WHEN clusters != "" THEN 1 ELSE 0 END) AS clusters,
+			MAX(slots_limit) AS slots,
+			MAX(jobs_limit) AS jobs,
+			MAX(mem_limit) AS mem,
+			MAX(swp_limit) AS swp,
+			MAX(tmp_limit) AS tmp,
+			MAX(fwd_tasks_limit) AS fwd_tasks
+			FROM grid_limits_history
+			WHERE clusterid = ?
+			AND limit_name = ?',
+			array($clusterid, $limit_name));
+
+		$limit_data[$limit_name . '|' . $clusterid] = $limits;
+	} else {
+		$limits = db_fetch_row_prepared('SELECT
+			SUM(CASE WHEN resources != "" THEN 1 ELSE 0 END) AS resources,
+			SUM(CASE WHEN users != "" THEN 1 ELSE 0 END) AS users,
+			SUM(CASE WHEN hosts != "" THEN 1 ELSE 0 END) AS hosts,
+			SUM(CASE WHEN queues != "" THEN 1 ELSE 0 END) AS queues,
+			SUM(CASE WHEN projects != "" THEN 1 ELSE 0 END) AS projects,
+			SUM(CASE WHEN lic_projects != "" THEN 1 ELSE 0 END) AS lic_projects,
+			SUM(CASE WHEN clusters != "" THEN 1 ELSE 0 END) AS clusters,
+			MAX(slots_limit) AS slots,
+			MAX(jobs_limit) AS jobs,
+			MAX(mem_limit) AS mem,
+			MAX(swp_limit) AS swp,
+			MAX(tmp_limit) AS tmp,
+			MAX(fwd_tasks_limit) AS fwd_tasks
+			FROM grid_limits_history
+			WHERE limit_name = ?',
+			array($limit_name));
+
+		$limit_data[$limit_name . '|' . $clusterid] = $limits;
+	}
+
+	if (cacti_sizeof($limits)) {
+		$name = str_replace('_usage', '', $name);
+
+		if (isset($limits[$name]) && $limits[$name] == 0) {
+			return false;
+		} else {
+			return true;
+		}
+	} else {
+		return false;
+	}
+}
+
+function showColumn($name, $clusterid) {
+	$measure = get_request_var('measure');
+	$columns = getViewableColumns($clusterid, $measure);
+
+	if (strpos($name, '_usage') !== false) {
+		if ($name != $measure . '_usage') {
+			return false;
+		}
+	}
+
+	if (isset($columns[$name]) && $columns[$name] > 0) {
+		return true;
+	} elseif (!isset($columns[$name])) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+function getViewableColumns($clusterid, $measure) {
+	if (isset($_SESSION['sess_limits_cols'][$clusterid . '|' . $measure])) {
+		return $_SESSION['sess_limits_cols'][$clusterid . '|' . $measure];
+	} else {
+		$sql_where = '';
+
+		$sql = "SELECT
+			SUM(CASE WHEN per_user != '' THEN 1 ELSE 0 END) AS per_user,
+			SUM(CASE WHEN per_host != '' THEN 1 ELSE 0 END) AS per_host,
+			SUM(CASE WHEN per_queue != '' THEN 1 ELSE 0 END) AS per_queue,
+			SUM(CASE WHEN per_project != '' THEN 1 ELSE 0 END) AS per_project,
+			SUM(CASE WHEN per_lic_project != '' THEN 1 ELSE 0 END) AS per_lic_project,
+			SUM(CASE WHEN users != '' THEN 1 ELSE 0 END) AS users,
+			SUM(CASE WHEN hosts != '' THEN 1 ELSE 0 END) AS hosts,
+			SUM(CASE WHEN queues != '' THEN 1 ELSE 0 END) AS queues,
+			SUM(CASE WHEN projects != '' THEN 1 ELSE 0 END) AS projects,
+			SUM(CASE WHEN lic_projects != '' THEN 1 ELSE 0 END) AS lic_projects,
+			MAX(slots) AS slots,
+			MAX(mem) AS mem,
+			MAX(swp) AS swp,
+			MAX(tmp) AS tmp,
+			MAX(jobs) AS jobs,
+			MAX(fwd_tasks) AS fwd_tasks
+			FROM grid_limits";
+
+		if ($clusterid > 0) {
+			$sql_where .= ' WHERE clusterid = ' . $clusterid;
+		}
+
+		if ($measure != '' && $measure != 'resources') {
+			$sql_where .= ($sql_where != '' ? ' AND ':' WHERE ') . $measure . ' > 0';
+		} elseif ($measure != '' && $measure == 'resources') {
+			$sql_where .= ($sql_where != '' ? ' AND ':' WHERE ') . 'resources != ""';
+		}
+
+		$_SESSION['sess_limits_cols'][$clusterid . '|' . $measure] = db_fetch_row($sql . $sql_where);
+
+		return $_SESSION['sess_limits_cols'][$clusterid . '|' . $measure];
+	}
+}
+
+function nf18n($string, $digits = 0) {
+	if ($string == '-') {
+		return $string;
+	} elseif ($string === null) {
+		return '-';
+	} else {
+		return number_format_i18n($string, $digits);
+	}
+}
+
+function drawLimitsRows($rows) {
+	global $config;
+
+	$sql = getLimitsSQL();
+
+	$total_rows = 0;
+
+	# Add the row limits to the query
+	$sql .= ' LIMIT ' . ($rows*($_REQUEST['page']-1)) . ',' . $rows;
+
+	$data = getLimitsRows($sql, $total_rows);
+
+	$filter = get_request_var('filter');
+	$cid    = get_request_var('clusterid');
+
+	$i = 0;
+	foreach ($data as $row) {
+		$url = $config['url_path'] . 'plugins/gridlimits/grid_limits.php' .
+			'?action=usage' .
+			'&reset=true' .
+			'&clusterid=' . $row['clusterid'] .
+			'&limit_name=' . $row['limit_name'];
+
+		if ($row['resources'] != '') {
+			$parts = explode(' / ', $row['resources']);
+			$url .= '&resource=' . $parts[0];
+		}
+
+		form_alternate_row('line_' . $i, true); $i++;
+
+		form_selectable_ecell($row['cluster_name'], $i);
+		form_selectable_cell(filter_value($row['limit_name'], get_request_var('filter'), $url), $i);
+
+		if (showColumn('slots_usage', $cid)) {
+			form_selectable_cell(nf18n($row['slots_usage']) . '/' . nf18n($row['slots']) . ($row['slots_per_processor'] == 'Y' ? ' per processor':''), $i, '', 'right');
+		}
+
+		if (showColumn('mem_usage', $cid)) {
+			form_selectable_cell(nf18n($row['mem_usage']) . ' / ' . nf18n($row['mem']) . ($row['mem_percent'] == 'Y' ? '%':' ' . $row['unit_for_limits']), $i, '', 'right');
+		}
+
+		if (showColumn('swp_usage', $cid)) {
+			form_selectable_cell(nf18n($row['swp_usage']) . ' / ' . nf18n($row['swp']) . ($row['swp_percent'] == 'Y' ? '%':' ' . $row['unit_for_limits']), $i, '', 'right');
+		}
+
+		if (showColumn('tmp_usage', $cid)) {
+			form_selectable_cell(nf18n($row['tmp_usage']) . ' / ' . nf18n($row['tmp']) . ($row['tmp_percent'] == 'Y' ? '%':' ' . $row['unit_for_limits']), $i, '', 'right');
+		}
+
+		if (showColumn('jobs_usage', $cid)) {
+			form_selectable_cell(nf18n($row['jobs_usage']) . '/' . nf18n($row['jobs']), $i, '', 'right');
+		}
+
+		if (showColumn('fwd_tasks_usage', $cid)) {
+			form_selectable_cell(nf18n($row['fwd_tasks_usage']) . ' / ' . nf18n($row['fwd_tasks']), $i, '', 'right');
+		}
+
+		if (showColumn('users', $cid)) {
+			form_selectable_cell(filter_value($row['users'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		if (showColumn('per_user', $cid)) {
+			form_selectable_cell(filter_value($row['per_user'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		if (showColumn('hosts', $cid)) {
+			form_selectable_cell(filter_value($row['hosts'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		if (showColumn('per_host', $cid)) {
+			form_selectable_cell(filter_value($row['per_host'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		if (showColumn('queues', $cid)) {
+			form_selectable_cell(filter_value($row['queues'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		if (showColumn('per_queue', $cid)) {
+			form_selectable_cell(filter_value($row['per_queue'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		if (showColumn('projects', $cid)) {
+			form_selectable_cell(filter_value($row['projects'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		if (showColumn('per_project', $cid)) {
+			form_selectable_cell(filter_value($row['per_project'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		if (showColumn('lic_projects', $cid)) {
+			form_selectable_cell(filter_value($row['lic_projects'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		if (showColumn('per_lic_project', $cid)) {
+			form_selectable_cell(filter_value($row['per_lic_project'], get_request_var('filter')), $i, '', 'white-space:normal !important');
+		}
+
+		form_selectable_cell(filter_value($row['resources'], get_request_var('filter')), $i, '', 'white-space:normal !important;text-align:right;');
+
+		form_selectable_cell($row['last_use'], $i, '', 'right');
+
+		form_end_row();
+	}
+}
+
+function drawLimitsTable() {
+	global $config;
+
+	/* ================= input validation and session storage ================= */
+	$filters = array(
+		'rows' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'pageset' => true,
+			'default' => '-1'
+		),
+		'page' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'default' => '1'
+		),
+		'clusterid' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'pageset' => true,
+			'default' => '-1'
+		),
+		'class' => array(
+			'filter' => FILTER_CALLBACK,
+			'default' => 'users',
+			'options' => array('options' => 'sanitize_search_string')
+		),
+		'measure' => array(
+			'filter' => FILTER_CALLBACK,
+			'default' => '-1',
+			'options' => array('options' => 'sanitize_search_string')
+		),
+		'sort_column' => array(
+			'filter' => FILTER_CALLBACK,
+			'default' => 'limit_name',
+			'options' => array('options' => 'sanitize_search_string')
+		),
+		'sort_direction' => array(
+			'filter' => FILTER_CALLBACK,
+			'default' => 'ASC',
+			'options' => array('options' => 'sanitize_search_string')
+		),
+		'limit_name' => array(
+			'filter' => FILTER_CALLBACK,
+			'default' => '-1',
+			'options' => array('options' => 'sanitize_search_string')
+		)
+	);
+
+	validate_store_request_vars($filters, 'sess_limit');
+
+	$filters = array(
+		'clusterid' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'pageset' => true,
+			'default' => read_grid_config_option('default_grid')
+		)
+	);
+
+	validate_store_request_vars($filters, 'sess_grid');
+	/* ================= input validation ================= */
+
+	if (get_request_var('rows') == '-1') {
+		$rows = read_config_option('num_rows_table');
+	} else {
+		$rows = get_request_var('rows');
+	}
+
+	general_header();
+
+	drawTabs();
+
+	drawLimitsFilter();
+
+	$sql = 'SELECT COUNT(*) FROM (' . getLimitsSQL() . ') a';
+
+	$total_rows = db_fetch_cell($sql);
+
+	$headers = getTableHeaders();
+
+	$nav = html_nav_bar($config['url_path'] . 'plugins/gridlimits/grid_limits.php?action=limits&filter=' . get_request_var('filter'), MAX_DISPLAY_PAGES, get_request_var('page'), $rows, $total_rows, cacti_sizeof($headers), __('Limits', 'gridlimits'), 'page', 'main');
+
+	print $nav;
+
+	html_start_box('', '100%', '', '3', 'center', '');
+
+	html_header_sort($headers, get_request_var('sort_column'), get_request_var('sort_direction'), 1, $config['url_path'] . 'plugins/gridlimits/grid_limits.php?action=limits');
+
+	if ($total_rows) {
+		drawLimitsRows($rows);
+	} else {
+		print '<tr><td colspan="' . cacti_sizeof($headers) . '"><em>' . __('No Matching Limit Records Found', 'gridlimits') . '</em></td></tr>';
+	}
+
+	html_end_box(false);
+
+	if ($total_rows) {
+		print $nav;
+	}
+
+	bottom_footer();
+}
+
+function getLimitsSQL() {
+	$date = date('Y-m-d H:i:s', time() - 86400);
+
+	$measure = get_request_var('measure');
+
+	$sql_query = "SELECT gc.clustername as cluster_name, gl.clusterid, gl.limit_name,
+		IFNULL(gl.users, '-') AS users, IFNULL(gl.per_user, '-') AS per_user,
+		IFNULL(gl.hosts, '-') AS hosts, IFNULL(gl.per_host, '-') AS per_host,
+		IFNULL(gl.queues, '-') AS queues, IFNULL(gl.per_queue, '-') AS per_queue,
+		IFNULL(gl.projects, '-') AS projects, IFNULL(gl.per_project, '-') AS per_project,
+		IFNULL(gl.lic_projects, '-') AS lic_projects, IFNULL(gl.per_lic_project, '-') AS per_lic_project,
+		slots, slots_usage, slots_per_processor,
+		mem, mem_usage, mem_percent,
+		swp, swp_usage, swp_percent,
+		tmp, tmp_usage, tmp_percent,
+		jobs, jobs_usage, IFNULL(resources, '-') AS resources,
+		fwd_tasks, fwd_tasks_usage,
+		unit_for_limits,
+		last_updated AS last_use
+		FROM grid_limits AS gl
+		INNER JOIN grid_clusters AS gc
+		ON gl.clusterid = gc.clusterid";
+
+	if ($measure == 'resources') {
+		$sql_where = 'WHERE resources != ""';
+	} else {
+		$sql_where = "WHERE $measure > 0";
+	}
+
+	if (get_nfilter_request_var('filter') != '') {
+		$fields = array(
+			'limit_name',
+			'users',
+			'per_user',
+			'queues',
+			'per_queue',
+			'hosts',
+			'per_host',
+			'projects',
+			'per_project',
+			'lic_projects',
+			'per_lic_project',
+			'resources'
+		);
+
+		if (get_nfilter_request_var('filter') != '') {
+			$sql_where .= ' AND (';
+			$i = 0;
+
+			foreach($fields as $field) {
+				$sql_where .= ($i == 0 ? '':' OR ') . $field . ' LIKE ' . db_qstr('%' . get_nfilter_request_var('filter') . '%');
+				$i++;
+			}
+
+			$sql_where .= ')';
+		}
+	}
+
+	if (get_filter_request_var('clusterid') > 0) {
+		$sql_where .= ' AND gl.clusterid = ' . get_request_var('clusterid');
+	}
+
+	if (get_request_var('class') != -1) {
+		switch (get_request_var('class')) {
+			case 'user':
+				$sql_where .= ' AND (gl.users != "" OR gl.per_user != "")';
+
+				break;
+			case 'project':
+				$sql_where .= ' AND (gl.projects != "" OR gl.per_project != "")';
+
+				break;
+			case 'lic_project':
+				$sql_where .= ' AND (gl.lic_projects != "" OR gl.per_lic_project != "")';
+
+				break;
+			case 'host':
+				$sql_where .= ' AND (gl.hosts != "" OR gl.per_host != "")';
+
+				break;
+			case 'queue':
+				$sql_where .= ' AND (gl.queues != "" OR gl.per_queue != "")';
+
+				break;
+		}
+	}
+
+	$sql_order = get_order_string();
+
+	$sql = "$sql_query $sql_where $sql_order";
+
+	//cacti_log(str_replace("\n", ' ', str_replace("\t", '', $sql)));
+
+	return $sql;
+}
+
+function getLimitsRows($sql_query, &$total_rows = 0) {
+	$rows = db_fetch_assoc($sql_query);
+	$new_rows = array();
+
+	if (cacti_sizeof($rows)) {
+		foreach($rows as $r) {
+			if ($r['resources'] != '') {
+				$resources = explode(' ', trim($r['resources']));
+
+				foreach($resources as $res) {
+					if (!is_numeric($res)) {
+						$r['resources'] = $res . ' / ';
+					} else {
+						$r['resources'] .= $res;
+						$new_rows[] = $r;
+					}
+				}
+			} else {
+				$new_rows[] = $r;
+			}
+		}
+	}
+
+	$total_rows = cacti_sizeof($total_rows);
+
+	return $new_rows;
+}
+
+function checkChanged($request, $session) {
+	if ((isset($_REQUEST[$request])) && (isset($_SESSION[$session]))) {
+		if ($_REQUEST[$request] != $_SESSION[$session]) {
+			return 1;
+		}
+	}
+}
+
+function getTableHeaders() {
+	$headers = array(
+		'cluster_name' => array(
+			'display' => __('Cluster Name', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'limit_name' => array(
+			'display' => __('Limit Name', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'slots_usage' => array(
+			'display' => __('Slots', 'gridlimits'),
+			'align' => 'right',
+			'sort' => 'DESC'
+		),
+		'mem_usage' => array(
+			'display' => __('Memory', 'gridlimits'),
+			'align' => 'right',
+			'sort' => 'DESC'
+		),
+		'swp_usage' => array(
+			'display' => __('Swap', 'gridlimits'),
+			'align' => 'right',
+			'sort' => 'DESC'
+		),
+		'tmp_usage' => array(
+			'display' => __('Tmp', 'gridlimits'),
+			'align' => 'right',
+			'sort' => 'DESC'
+		),
+		'jobs_usage' => array(
+			'display' => __('Jobs', 'gridlimits'),
+			'align' => 'right',
+			'sort' => 'DESC'
+		),
+		'fwd_tasks_usage' => array(
+			'display' => __('Forwarded Tasks', 'gridlimits'),
+			'align' => 'right',
+			'sort' => 'DESC'
+		),
+		'users' => array(
+			'display' => __('Users', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'per_user' => array(
+			'display' => __('Per User', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'hosts' => array(
+			'display' => __('Hosts', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'per_host' => array(
+			'display' => __('Per Host', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'queues' => array(
+			'display' => __('Queues', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'per_queue' => array(
+			'display' => __('Per Queue', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'projects' => array(
+			'display' => __('Projects', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'per_project' => array(
+			'display' => __('Per Project', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'lic_projects' => array(
+			'display' => __('License Project', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'per_lic_project' => array(
+			'display' => __('Per License Project', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'resources' => array(
+			'display' => __('Resources', 'gridlimits'),
+			'sort' => 'ASC'
+		),
+		'last_use' => array(
+			'display' => __('Last Seen', 'gridlimits'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		)
+	);
+
+	$cid = get_request_var('clusterid');
+
+	foreach($headers as $name => $data) {
+		if (!showColumn($name, $cid)) {
+			unset($headers[$name]);
+		}
+	}
+
+	return $headers;
+}
+
+function drawUsePage() {
+	general_header();
+
+	drawTabs();
+
+	# Draw the data table for this page
+	drawUseTable();
+
+	# Draw the Javascript we need for the dashboard updates
+	drawUseJavascript();
+
+	# Draw the dashboard for the limit
+	drawUseDashboard();
+
+	bottom_footer();
+}
+
+function drawUseFilter() {
+	global $config, $grid_rows_selector, $title;
+
+	html_start_box($title, '100%', '', '3', 'center', '');
+
+	if (!isset_request_var('limit_name') || get_nfilter_request_var('limit_name') == -1) {
+		$clusters = db_fetch_assoc('SELECT gc.clusterid, gc.clustername
+			FROM grid_clusters AS gc
+			INNER JOIN (SELECT DISTINCT clusterid FROM grid_limits) AS gl
+			ON gc.clusterid = gl.clusterid
+			WHERE gc.disabled = ""
+			ORDER BY clustername');
+	} else {
+		$clusters = db_fetch_assoc_prepared('SELECT DISTINCT gc.clusterid, gc.clustername
+			FROM grid_clusters AS gc
+			INNER JOIN grid_limits AS gl
+			ON gc.clusterid = gl.clusterid
+			WHERE gc.disabled = ""
+			AND gl.limit_name = ?
+			ORDER BY clustername',
+			array(get_nfilter_request_var('limit_name')));
+	}
+
+	if (get_request_var('clusterid') == '-1') {
+		$limits = db_fetch_assoc('SELECT limit_name, clusterid
+			FROM grid_limits
+			WHERE clusterid IN (SELECT clusterid FROM grid_clusters WHERE disabled="")');
+	} else {
+		$limits = db_fetch_assoc_prepared('SELECT limit_name, clusterid
+			FROM grid_limits
+			WHERE clusterid = ?',
+			array(get_request_var('clusterid')));
+	}
+
+	?>
+	<tr class='odd'>
+		<td>
+			<form id='form_limit'>
+			<table class='filterTable'>
+				<tr>
+					<td>
+						<?php print __('Cluster', 'gridlimits');?>
+					</td>
+					<td>
+						<select id='clusterid' onChange='applyFilter()'>
+						<?php
+
+						print '<option value="-1"' . (get_request_var('clusterid') == -1 ? ' selected':'') . '>' . __esc('All', 'gridlimits') . '</option>';
+
+						if (cacti_sizeof($clusters)) {
+							foreach ($clusters as $cluster) {
+								print '<option value="' . $cluster['clusterid'] . '"' . (get_request_var('clusterid') == $cluster['clusterid'] ? ' selected':'') . '>' . html_escape($cluster['clustername']) . '</option>';
+							}
+						}
+						?>
+						</select>
+					</td>
+					<td>
+						<?php print __('Limit', 'gridlimits');?>
+					</td>
+					<td>
+						<select id='limit_name' onChange='applyFilter()'>
+							<?php
+
+							print '<option value="-1"' . (get_request_var('limit_name') == -1 ? ' selected':'') . '>' . __esc('All', 'gridlimits') . '</option>';
+
+							if (cacti_sizeof($limits)) {
+								foreach ($limits as $limit) {
+									print '<option value="' . html_escape($limit['limit_name']) . '"' . (get_request_var('limit_name') == $limit['limit_name'] && get_request_var('clusterid') == $limit['clusterid'] ? ' selected':'') . '>' . html_escape($limit['limit_name']) . '</option>';
+								}
+							}
+							?>
+						</select>
+					</td>
+					<td>
+						<span>
+							<input id='go' type='submit' value='<?php print __('Go', 'gridlimits');?>'>
+							<input id='clear' type='button' value='<?php print __('Clear', 'gridlimits');?>'>
+						</span>
+					</td>
+				</tr>
+			</table>
+			<table class='filterTable'>
+				<tr>
+					<td>
+						<?php print __('Search', 'gridlimits');?>
+					</td>
+					<td>
+						<input type='text' id='filter' size='30' value='<?php print html_escape_request_var('filter');?>'>
+					</td>
+					<td>
+						<?php print __('Records', 'gridlimits');?>
+					</td>
+					<td>
+						<select id='rows' onChange='applyFilter()'>
+							<?php
+							if (cacti_sizeof($grid_rows_selector)) {
+								foreach ($grid_rows_selector as $key => $value) {
+									print '<option value="' . $key . '"' . (get_request_var('rows') == $key ? ' selected':'') . '>' . $value . '</option>';
+								}
+							}
+							?>
+						</select>
+					</td>
+				</tr>
+			</table>
+			</form>
+			<script type='text/javascript'>
+
+			function applyFilter() {
+				strURL  = 'grid_limits.php?header=false';
+				strURL += '&action=usage';
+				strURL += '&rows='       + $('#rows').val();
+				strURL += '&clusterid='  + $('#clusterid').val();
+				strURL += '&filter='     + $('#filter').val();
+				strURL += '&limit_name=' + $('#limit_name').val();
+				loadPageNoHeader(strURL);
+			}
+
+			function clearFilter() {
+				strURL  = 'grid_limits.php?header=false';
+				strURL += '&action=usage';
+				strURL += '&clear=true';
+				loadPageNoHeader(strURL);
+			}
+
+			$(function() {
+				$('#form_limit').submit(function(event) {
+					event.preventDefault();
+					applyFilter();
+				});
+
+				$('#clear').click(function() {
+					clearFilter();
+				});
+
+				$('.fa-search').click(function() {
+					applyFilter();
+				});
+			});
+
+			</script>
+		</td>
+	</tr>
+
+	<?php
+
+	html_end_box();
+}
+
+function drawUseRows($rows) {
+	global $config;
+
+	$sql = getUseSQL();
+
+	# Add the row limits to the query
+	$sql .= " LIMIT " . ($rows*($_REQUEST["page"]-1)) . "," . $rows;
+
+	//cacti_log(str_replace("\n", ' ', str_replace("\t", '', $sql)));
+
+	$data  = getUseRows($sql);
+	$limit = get_request_var('limit_name');
+	$cid   = get_request_var('clusterid');
+
+	foreach ($data as $row) {
+		form_alternate_row('line_' . $row['sequenceid']);
+
+		$url = '<i class="tholdGlyphChart fas fa-chart-area" title="' . __('Show Usage History') . '"></i>' . $row['last_updated'];
+
+		form_selectable_cell($url, $row['sequenceid']);
+		form_selectable_cell($row['cluster_name'], $row['sequenceid']);
+		form_selectable_cell($row['limit_name'], $row['sequenceid']);
+
+		if (showLimitColumn('users', $limit, $cid)) {
+			form_selectable_cell(filter_value($row['users'], get_request_var('filter')), $row['sequenceid']);
+		}
+
+		if (showLimitColumn('hosts', $limit, $cid)) {
+			form_selectable_cell(filter_value($row['hosts'], get_request_var('filter')), $row['sequenceid']);
+		}
+
+		if (showLimitColumn('queues', $limit, $cid)) {
+			form_selectable_cell(filter_value($row['queues'], get_request_var('filter')), $row['sequenceid']);
+		}
+
+		if (showLimitColumn('projects', $limit, $cid)) {
+			form_selectable_cell(filter_value($row['projects'], get_request_var('filter')), $row['sequenceid']);
+		}
+
+		if (showLimitColumn('lic_projects', $limit, $cid)) {
+			form_selectable_cell(filter_value($row['lic_projects'], get_request_var('filter')), $row['sequenceid']);
+		}
+
+		if (showLimitColumn('clusters', $limit, $cid)) {
+			form_selectable_cell(filter_value($row['clusters'], get_request_var('filter')), $row['sequenceid']);
+		}
+
+		if (showLimitColumn('slots', $limit, $cid)) {
+			form_selectable_cell($row['slots'], $row['sequenceid'], '', 'right');
+		}
+
+		if (showLimitColumn('mem', $limit, $cid)) {
+			form_selectable_cell($row['mem'], $row['sequenceid'], '', 'right');
+		}
+
+		if (showLimitColumn('swp', $limit, $cid)) {
+			form_selectable_cell($row['swp'], $row['sequenceid'], '', 'right');
+		}
+
+		if (showLimitColumn('tmp', $limit, $cid)) {
+			form_selectable_cell($row['tmp'], $row['sequenceid'], '', 'right');
+		}
+
+		if (showLimitColumn('jobs', $limit, $cid)) {
+			form_selectable_cell($row['jobs'], $row['sequenceid'], '', 'right');
+		}
+
+		if (showLimitColumn('fwd_tasks', $limit, $cid)) {
+			form_selectable_cell($row['fwd_tasks'], $row['sequenceid'], '', 'right');
+		}
+
+		if (showLimitColumn('resources', $limit, $cid)) {
+			form_selectable_cell(filter_value($row['resources'], get_request_var('filter')), $row['sequenceid'], '', 'text-align:right;white-space:pre-wrap');
+		}
+
+		form_end_row();
+	}
+}
+
+function validateUseVariables() {
+	/* ================= input validation and session storage ================= */
+	$filters = array(
+		'rows' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'pageset' => true,
+			'default' => '-1'
+		),
+		'page' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'default' => '1'
+		),
+		'time_period' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'pageset' => true,
+			'default' => '3'
+		),
+		'filter' => array(
+			'filter' => FILTER_CALLBACK,
+			'pageset' => true,
+			'default' => '',
+			'options' => array('options' => 'sanitize_search_string')
+		),
+		'sort_column' => array(
+			'filter' => FILTER_CALLBACK,
+			'default' => 'last_updated',
+			'options' => array('options' => 'sanitize_search_string')
+		),
+		'sort_direction' => array(
+			'filter' => FILTER_CALLBACK,
+			'default' => 'DESC',
+			'options' => array('options' => 'sanitize_search_string')
+		),
+		'limit_name' => array(
+			'filter' => FILTER_CALLBACK,
+			'default' => '-1',
+			'options' => array('options' => 'sanitize_search_string')
+		)
+	);
+
+	validate_store_request_vars($filters, 'sess_limit_usage');
+
+	$filters = array(
+		'clusterid' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'pageset' => true,
+			'default' => read_grid_config_option('default_grid')
+		)
+	);
+
+	validate_store_request_vars($filters, 'sess_grid');
+	/* ================= input validation ================= */
+}
+
+function drawUseTable() {
+	global $config;
+
+	validateUseVariables();
+
+	if (get_request_var('rows') == '-1') {
+		$rows = read_config_option('num_rows_table');
+	} else {
+		$rows = get_request_var('rows');
+	}
+
+	drawUseFilter();
+
+	$sql = 'SELECT COUNT(*) FROM (' . getUseSQL() . ') a';
+
+	$total_rows = db_fetch_cell($sql);
+
+	$headers = getUseTableHeaders();
+
+	$nav = html_nav_bar($config['url_path'] . 'plugins/gridlimits/grid_limits.php?action=usage&filter=' . get_request_var('filter'), MAX_DISPLAY_PAGES, get_request_var('page'), $rows, $total_rows, cacti_sizeof($headers), __('Limits', 'gridlimits'), 'page', 'main');
+
+	print "<div id='limitTab'>";
+
+	print $nav;
+
+	html_start_box('', '100%', '', '3', 'center', '');
+
+	html_header_sort($headers, get_request_var('sort_column'), get_request_var('sort_direction'), 1, $config['url_path'] . 'plugins/gridlimits/grid_limits.php?action=usage');
+
+    if ($total_rows) {
+        drawUseRows($rows);
+    } else {
+        print '<tr><td colspan="' . cacti_sizeof($headers) . '"><em>' . __('No Matching Limit Records Found', 'gridlimits') . '</em></td></tr>';
+    }
+
+    html_end_box(false);
+
+	if ($total_rows) {
+		print $nav;
+	}
+
+	print '</div>';
+}
+
+function getUseSQL() {
+	$sql_query = "SELECT glh.sequenceid, glh.last_seen AS last_updated,
+		gc.clustername as cluster_name, glh.clusterid, glh.limit_name,
+		IFNULL(glh.users, '-') AS users,
+		IFNULL(glh.hosts, '-') AS hosts,
+		IFNULL(glh.queues, '-') AS queues,
+		IFNULL(glh.projects, '-') AS projects,
+		IFNULL(glh.lic_projects, '-') AS lic_projects,
+		IFNULL(glh.clusters, '-') AS clusters,
+		CONCAT(slots_usage, '/', slots_limit) AS slots,
+		CONCAT(mem_usage, '/', mem_limit, ' ', unit_for_limits) AS mem,
+		CONCAT(swp_usage, '/', swp_limit, ' ', unit_for_limits) AS swp,
+		CONCAT(tmp_usage, '/', tmp_limit, ' ', unit_for_limits) AS tmp,
+		CONCAT(jobs_usage, '/', jobs_limit) AS jobs,
+		IFNULL(resources, '-') AS resources,
+		CONCAT(fwd_tasks_usage, '/', fwd_tasks_limit) AS fwd_tasks
+		FROM grid_limits_history AS glh
+		INNER JOIN grid_clusters AS gc
+		ON glh.clusterid = gc.clusterid";
+
+	# Set the WHERE clause for this query
+	$sql_where = '';
+
+	# Add the filter to the query
+	if (get_request_var('limit_name') != '' && get_request_var('limit_name') != '-1') {
+		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . ' glh.limit_name = ' . db_qstr(get_request_var('limit_name'));
+	}
+
+	# Add the clusterid to the query
+	if (get_request_var('clusterid') > 0) {
+		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . ' glh.clusterid = ' . get_request_var('clusterid');
+	}
+
+	# Add the the filter to the query
+	if (get_request_var('filter') != "") {
+		$filter = db_qstr('%' . get_request_var('filter') . '%');
+
+		if ($sql_where != "") {
+			$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . " (
+				glh.users LIKE $filter OR
+				glh.queues LIKE $filter OR
+				glh.hosts LIKE $filter OR
+				glh.projects LIKE $filter OR
+				glh.lic_projects LIKE $filter OR
+				glh.clusters LIKE $filter OR
+				glh.resources LIKE $filter
+			)";
+		}
+	}
+
+	# Set the ORDER BY clause for this query
+	$sql_order = get_order_string();
+
+	$sql = "$sql_query $sql_where $sql_order";
+
+	return $sql;
+}
+
+function getUseRows($sql_query) {
+	return db_fetch_assoc($sql_query);
+}
+
+function getUseTableHeaders() {
+	$headers = array(
+		'last_updated' => array(
+			'display' => __('Last Seen Date', 'gridlimits'),
+			'sort'    => 'DESC'
+		),
+		'cluster_name' => array(
+			'display' => __('Cluster Name', 'gridlimits'),
+			'sort'    => 'ASC'
+		),
+		'limit_name' => array(
+			'display' => __('Limit Name', 'gridlimits'),
+			'sort'    => 'ASC'
+		),
+		'users' => array(
+			'display' => __('Users', 'gridlimits'),
+			'sort'    => 'ASC'
+		),
+		'hosts' => array(
+			'display' => __('Hosts', 'gridlimits'),
+			'sort'    => 'ASC'
+		),
+		'queues' => array(
+			'display' => __('Queues', 'gridlimits'),
+			'sort'    => 'ASC'
+		),
+		'projects' => array(
+			'display' => __('Projects', 'gridlimits'),
+			'sort'    => 'ASC'
+		),
+		'lic_projects' => array(
+			'display' => __('License Project', 'gridlimits'),
+			'sort'    => 'ASC'
+		),
+		'clusters' => array(
+			'display' => __('Clusters', 'gridlimits'),
+			'sort'    => 'ASC'
+		),
+		'slots_usage' => array(
+			'display' => __('Slots', 'gridlimits'),
+			'align'   => 'right',
+			'sort'    => 'DESC'
+		),
+		'mem_usage' => array(
+			'display' => __('Memory', 'gridlimits'),
+			'align'   => 'right',
+			'sort'    => 'DESC'
+		),
+		'swp_usage' => array(
+			'display' => __('Swap', 'gridlimits'),
+			'align'   => 'right',
+			'sort'    => 'DESC'
+		),
+		'tmp_usage' => array(
+			'display' => __('Tmp', 'gridlimits'),
+			'align'   => 'right',
+			'sort'    => 'DESC'
+		),
+		'jobs_usage' => array(
+			'display' => __('Jobs', 'gridlimits'),
+			'align'   => 'right',
+			'sort'    => 'DESC'
+		),
+		'fwd_tasks_usage' => array(
+			'display' => __('Fwd Tasks', 'gridlimits'),
+			'align'   => 'right',
+			'sort'    => 'DESC'
+		),
+		'resources' => array(
+			'display' => __('Resources', 'gridlimits'),
+			'align'   => 'right',
+			'sort'    => 'ASC'
+		)
+	);
+
+	$limit = get_request_var('limit_name');
+	$cid   = get_request_var('clusterid');
+
+	foreach($headers as $name => $data) {
+		if (!showLimitColumn($name, $limit, $cid)) {
+			unset($headers[$name]);
+		}
+	}
+
+	return $headers;
+}
+
+function drawUseDashboard() {
+	global $title;
+
+	$title = __('Limit Usage History', 'gridlimits');
+
+	$time_period = array(
+		1 => __esc('%d Hours', 2,  'gridlimits'),
+		2 => __esc('%d Hours', 6,  'gridlimits'),
+		3 => __esc('%d Hours', 12, 'gridlimits'),
+		4 => __esc('%d Day',   1,  'gridlimits'),
+		5 => __esc('%d Days',  2,  'gridlimits'),
+		6 => __esc('%d Week',  1,  'gridlimits'),
+		7 => __esc('%d Weeks', 2,  'gridlimits')
+	);
+
+	html_start_box($title, '100%', '', '3', 'center', '');
+
+	?>
+	<tr class='odd'>
+		<td>
+			<form name='form_limit_graph'>
+				<table class='filterTable'>
+					<tr>
+						<td>
+							Time Period
+						</td>
+						<td>
+							<select id='time_period' onChange='applyGraphFilterChange()'>
+								<?php
+								foreach ($time_period as $key => $value) {
+									print '<option value="' . $key . '"' . (get_request_var('time_period') == $key ? ' selected':'') . '>' . $value . '</option>';
+								}
+								?>
+							</select>
+						</td>
+					</tr>
+				</table>
+			</form>
+		</td>
+	</tr>
+	<script type='text/javascript'>
+
+	function applyGraphFilterChange() {
+		if (sequenceid == null) {
+			return;
+		}
+
+		var time_period = $('#time_period').val();
+
+		$('#chartContainer').html('');
+
+		$.ajax({
+			url: urlPath+'plugins/gridlimits/grid_limits.php?action=getChartCount&sequenceid='+sequenceid,
+			dataType: 'json',
+			data: '',
+			success: function(data, status, xhr) {
+				for (var key in data) {
+					if (data.hasOwnProperty(key)) {
+						var val = data[key];
+
+						// Get the historic data for this key
+						renderChart(key, 'chartContainer', sequenceid, time_period);
+					}
+				}
+			},
+			error: function(xhr, status, error) {
+				;
+			}
+		});
+	}
+
+	</script>
+
+	<?php
+
+	html_end_box(false);
+
+	print "<tr>
+		<td class='cactiTable'>
+			<div id='chartContainer' style='text-align:center'>
+				<table class='cactiTable'>
+					<tr>
+						<td>Select a limit to display</td>
+					</tr>
+				</table>
+			</div>
+		</td>
+	</tr>";
+
+	html_end_box(false);
+}
+
+function drawUseJavascript() {
+	?>
+	<script type='text/javascript'>
+	var sequenceid;
+
+	function renderChart(resource, container, sequenceid, time_period) {
+		$('#'+container).append('<br/><div class="center" id="'+sequenceid+'_'+resource+'"></div><br/>');
+
+		var chart = new FusionCharts({
+			'type': 'msline',
+        	'renderAt': sequenceid+'_'+resource,
+        	'width': $('#main').width()-40,
+        	'height': '500',
+        	'dataFormat': 'jsonurl',
+        	'dataSource': urlPath+'plugins/gridlimits/grid_limits.php?action=getData&sequenceid='+sequenceid+'&resource='+resource+'&time_period='+time_period
+      	});
+
+		chart.render();
+	}
+
+	$(function() {
+		$('.selectable').on('click', function(event) {
+			sequenceid = $(this).attr('id').replace('line_', '');
+
+			$('.selectable').not('#line_' + sequenceid).removeClass('selected');
+
+			var time_period = $('#time_period').val();
+
+			$('#chartContainer').html('');
+
+			$.ajax({
+				url: urlPath+'plugins/gridlimits/grid_limits.php?action=getChartCount&sequenceid='+sequenceid,
+				dataType: 'json',
+				data: '',
+				success: function(data, status, xhr) {
+					for (var key in data) {
+						if (data.hasOwnProperty(key)) {
+							var val = data[key];
+
+							// Get the historic data for this key
+							renderChart(key, 'chartContainer', sequenceid, time_period);
+						}
+					}
+				},
+				error: function(xhr, status, error) {
+					;
+				}
+			});
+		});
+	});
+	</script>
+	<?php
+}

--- a/cacti/plugins/gridlimits/index.php
+++ b/cacti/plugins/gridlimits/index.php
@@ -1,0 +1,21 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright IBM Corp. 2006, 2025                                          |
+ |                                                                         |
+ | Licensed under the Apache License, Version 2.0 (the "License");         |
+ | you may not use this file except in compliance with the License.        |
+ | You may obtain a copy of the License at                                 |
+ |                                                                         |
+ | http://www.apache.org/licenses/LICENSE-2.0                              |
+ |                                                                         |
+ | Unless required by applicable law or agreed to in writing, software     |
+ | distributed under the License is distributed on an "AS IS" BASIS,       |
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.|
+ | See the License for the specific language governing permissions and     |
+ | limitations under the License.                                          |
+ +-------------------------------------------------------------------------+
+*/
+
+header('Location:../index.php');
+

--- a/cacti/plugins/gridlimits/poller_gridlimits.php
+++ b/cacti/plugins/gridlimits/poller_gridlimits.php
@@ -1,0 +1,326 @@
+#!/usr/bin/env php
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright IBM Corp. 2006, 2025                                          |
+ |                                                                         |
+ | Licensed under the Apache License, Version 2.0 (the "License");         |
+ | you may not use this file except in compliance with the License.        |
+ | You may obtain a copy of the License at                                 |
+ |                                                                         |
+ | http://www.apache.org/licenses/LICENSE-2.0                              |
+ |                                                                         |
+ | Unless required by applicable law or agreed to in writing, software     |
+ | distributed under the License is distributed on an "AS IS" BASIS,       |
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.|
+ | See the License for the specific language governing permissions and     |
+ | limitations under the License.                                          |
+ +-------------------------------------------------------------------------+
+*/
+
+include(dirname(__FILE__) . '/../../include/cli_check.php');
+include_once($config['library_path'] . '/rtm_functions.php');
+include_once($config['library_path'] . '/poller.php');
+
+// Include core files
+include_once(dirname(__FILE__) . '/../grid/lib/grid_partitioning.php');
+include_once(dirname(__FILE__) . '/../grid/lib/grid_functions.php');
+
+ini_set('memory_limit', '-1');
+
+/* process calling arguments */
+$parms = $_SERVER['argv'];
+array_shift($parms);
+
+/* take the start time to log performance data */
+$start = microtime(true);
+
+$debug      = false;
+$force      = false;
+
+foreach($parms as $parameter) {
+	@list($arg, $value) = @explode('=', $parameter);
+
+	switch ($arg) {
+	case '-d':
+	case '--debug':
+		$debug = true;
+		break;
+	case '-f':
+	case '--force':
+		$force = true;
+		break;
+	case '-h':
+	case '-v':
+	case '-V':
+	case '--version':
+	case '--help':
+		display_help();
+		exit;
+	default:
+		print 'ERROR: Invalid Parameter ' . $parameter . "\n\n";
+		display_help();
+		exit;
+	}
+}
+
+$poller_interval = read_config_option('poller_interval');
+
+if (detect_and_correct_running_processes(0, 'GRIDLIMITS', $poller_interval*3) || $force) {
+	$last_run  = read_config_option('gridlimits_lastrun');
+	$now       = time();
+	$pass_last = $last_run;
+
+	if (empty($last_run)) {
+		$last_run = $now;
+	}
+
+	set_config_option('gridlimits_lastrun', $now);
+
+	if (date('z', $now) != date('z', $last_run)) {
+		$run_partition = true;
+	} else {
+		$run_partition = false;
+	}
+
+	// Get rollup statistics for the user interface
+	$limits = do_rollup($pass_last);
+
+	// Dump old records
+	do_purge();
+
+	// Partition the history and the job mapping tables
+	if ($run_partition) {
+		gridlimits_manage_partitions();
+	}
+
+	// Record end time for statistics and log statistics
+	$end = microtime(true);
+
+	$stats = 'GRIDLIMITS STATS: ' .
+		'Time:' . round($end - $start, 2) .
+		', Limits:' . $limits['limits'] .
+		', History:' . $limits['history'] .
+		', Clusters: ' . $limits['clusters'];
+
+	cacti_log($stats, false, 'SYSTEM');
+
+	remove_process_entry(0, 'GRIDLIMITS');
+
+	gridlimits_debug($stats);
+}
+
+function do_purge() {
+	$retention = read_config_option('grid_detail_data_retention') ?? '2weeks';
+
+	preg_match_all('!\d+!', $retention, $matches);
+
+	$num = $matches[0][0];
+	$str = preg_replace('/[0-9]+/', '', $retention);
+
+	# Translate into the string that the MySQL INTERVAL needs
+	if ($str == 'days') {
+		$str = 'day';
+	} elseif ($str == 'weeks') {
+		$str = 'week';
+	} elseif ($str == 'months') {
+		$str = 'month';
+	} elseif ($str == 'years') {
+		$str = 'year';
+	}
+
+	db_execute('DELETE FROM grid_limits
+		WHERE present = 0
+		AND last_updated < DATE_SUB(now(), INTERVAL ' . $num . ' ' . $str . ')');
+
+    db_execute('DELETE FROM grid_limits_history
+		WHERE last_seen < DATE_SUB(now(), INTERVAL ' . $num . ' ' . $str . ')');
+}
+
+function do_rollup($last_run) {
+	$last_updated = db_fetch_assoc("SELECT clusterid, MAX(last_updated) AS last_updated
+		FROM grid_limits_usage
+		GROUP BY clusterid");
+
+	$limits['clusters'] = cacti_sizeof($last_updated);
+	$limits['limits']   = 0;
+	$limits['history']  = 0;
+
+	if ($limits['clusters'] > 0) {
+		foreach($last_updated as $c) {
+			$format = array(
+				'clusterid', 'limit_name', 'clusters', 'resources_usage',
+                'slots_usage', 'slots_limit',
+                'mem_usage', 'mem_limit',
+                'swp_usage', 'swp_limit',
+                'tmp_usage', 'tmp_limit',
+                'jobs_usage', 'jobs_limit',
+                'fwd_tasks_usage', 'fwd_tasks_limit', 'last_updated'
+			);
+
+			$records = db_fetch_assoc_prepared("SELECT
+				clusterid, limit_name, clusters, resources AS resources_usage,
+				slots_usage, slots_limit,
+				mem_usage, mem_limit,
+				swp_usage, swp_limit,
+				tmp_usage, tmp_limit,
+				jobs_usage, jobs_limit,
+				fwd_tasks_usage, fwd_tasks_limit, last_updated
+				FROM grid_limits_usage
+				WHERE clusterid = ?
+				AND last_updated = ?",
+				array($c['clusterid'], $c['last_updated']));
+
+			$duplicate = 'ON DUPLICATE KEY UPDATE
+				clusters=VALUES(clusters),
+				resources_usage=VALUES(resources_usage),
+				slots_limit=VALUES(slots_limit),
+				slots_usage=VALUES(slots_usage),
+				mem_usage=VALUES(mem_usage),
+				mem_limit=VALUES(mem_limit),
+				swp_usage=VALUES(swp_usage),
+				swp_limit=VALUES(swp_limit),
+				tmp_usage=VALUES(tmp_usage),
+				tmp_limit=VALUES(tmp_limit),
+				jobs_usage=VALUES(jobs_usage),
+				jobs_limit=VALUES(jobs_limit),
+				fwd_tasks_usage=VALUES(fwd_tasks_usage),
+				fwd_tasks_limit=VALUES(fwd_tasks_limit),
+				last_updated=VALUES(last_updated)';
+
+			grid_pump_records($records, 'grid_limits', $format, false, $duplicate);
+
+			$limits['limits'] += db_fetch_cell_prepared('SELECT COUNT(clusterid)
+				FROM grid_limits_usage
+				WHERE clusterid = ?
+				AND last_updated = ?',
+				array($c['clusterid'], $c['last_updated']));
+		}
+
+		$format  = array(
+			'sequenceid',
+			'clusterid',
+			'limit_name',
+			'users',
+			'queues',
+			'hosts',
+			'projects',
+			'lic_projects',
+			'clusters',
+			'apps',
+			'resources',
+			'slots_usage',
+			'slots_limit',
+			'mem_usage',
+			'mem_limit',
+			'swp_usage',
+			'swp_limit',
+			'tmp_usage',
+			'tmp_limit',
+			'jobs_usage',
+			'jobs_limit',
+			'fwd_tasks_usage',
+			'fwd_tasks_limit',
+			'unit_for_limits',
+			'last_seen'
+		);
+
+		$params = array();
+		if (empty($last_run)) {
+			$sql_where = '';
+		} else {
+			$sql_where = 'WHERE last_updated >= ?';
+			$params[]  = date('Y-m-d H:i:s', $last_run);
+		}
+
+		$records = db_fetch_assoc_prepared("SELECT sequenceid,
+			clusterid, limit_name, users, queues, hosts, projects,
+			lic_projects, clusters, apps, resources,
+			slots_usage, slots_limit,
+			mem_usage, mem_limit,
+			swp_usage, swp_limit,
+			tmp_usage, tmp_limit,
+			jobs_usage, jobs_limit,
+			fwd_tasks_usage, fwd_tasks_limit,
+			unit_for_limits, MAX(last_updated) AS last_seen
+			FROM grid_limits_usage
+			$sql_where
+			GROUP BY
+				clusterid,
+				limit_name,
+				users,
+				queues,
+				hosts,
+				projects,
+				lic_projects,
+				clusters,
+				apps",
+			$params);
+
+		$duplicate = 'ON DUPLICATE KEY UPDATE
+			resources=VALUES(resources),
+			slots_limit=VALUES(slots_limit),
+			slots_usage=VALUES(slots_usage),
+			mem_usage=VALUES(mem_usage),
+			mem_limit=VALUES(mem_limit),
+			swp_usage=VALUES(swp_usage),
+			swp_limit=VALUES(swp_limit),
+			tmp_usage=VALUES(tmp_usage),
+			tmp_limit=VALUES(tmp_limit),
+			jobs_usage=VALUES(jobs_usage),
+			jobs_limit=VALUES(jobs_limit),
+			fwd_tasks_usage=VALUES(fwd_tasks_usage),
+			fwd_tasks_limit=VALUES(fwd_tasks_limit),
+			unit_for_limits=VALUES(unit_for_limits),
+			last_seen=VALUES(last_seen)';
+
+		grid_pump_records($records, 'grid_limits_history', $format, false, $duplicate);
+
+		$limits['history'] = cacti_sizeof($records);
+	} else {
+		db_execute('UPDATE grid_limits SET slots_usage=0, mem_usage=0, swp_usage=0, tmp_usage=0, jobs_usage=0, fwd_tasks_usage=0');
+	}
+
+	return $limits;
+}
+
+/**
+ * manage_partitions()
+ *
+ * A function to manage partitions of historical license data
+ */
+function gridlimits_manage_partitions() {
+	/* determine if a new partition needs to be created */
+	if (partition_timefor_create('grid_limits_usage', 'last_updated')) {
+		partition_create('grid_limits_usage', 'last_updated', 'last_updated');
+	}
+
+	/* remove old partitions if required */
+	grid_debug("Pruning Partitions for 'grid_limits_usage'");
+	partition_prune_partitions('grid_limits_usage');
+}
+
+/**
+ * A utility debugging function
+ *
+ * @param The message to be logged, if debugging is enabled
+ */
+function gridlimits_debug($mes) {
+	global $debug;
+
+	if ($debug) {
+		print date('m/d/Y H:i:s') . ' ' . trim($mes) . "\n";
+	}
+}
+
+/* display_help - displays the usage of the function */
+function display_help () {
+	print "RTM Limits Poller " . read_config_option("grid_version") . "\n";
+	print html_entity_decode('&#169;',ENT_NOQUOTES,'UTF-8')." Copyright International Business Machines Corp, " . read_config_option("grid_copyright_year") . ".\n\n";
+
+	print "Usage:\n";
+	print "poller_gridlimits.php [-f|--force] [-d|--debug]\n\n";
+	print "-f | --force       - Force License History Correlation\n";
+	print "-d | --debug       - Display verbose output during execution\n";
+}
+

--- a/cacti/plugins/gridlimits/setup.php
+++ b/cacti/plugins/gridlimits/setup.php
@@ -1,0 +1,259 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright IBM Corp. 2006, 2025                                          |
+ |                                                                         |
+ | Licensed under the Apache License, Version 2.0 (the "License");         |
+ | you may not use this file except in compliance with the License.        |
+ | You may obtain a copy of the License at                                 |
+ |                                                                         |
+ | http://www.apache.org/licenses/LICENSE-2.0                              |
+ |                                                                         |
+ | Unless required by applicable law or agreed to in writing, software     |
+ | distributed under the License is distributed on an "AS IS" BASIS,       |
+ | WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.|
+ | See the License for the specific language governing permissions and     |
+ | limitations under the License.                                          |
+ +-------------------------------------------------------------------------+
+*/
+
+function plugin_gridlimits_install() {
+	api_plugin_register_hook('gridlimits', 'config_arrays',        'gridlimits_config_arrays',        'setup.php');
+	api_plugin_register_hook('gridlimits', 'draw_navigation_text', 'gridlimits_draw_navigation_text', 'setup.php');
+	api_plugin_register_hook('gridlimits', 'poller_bottom',        'gridlimits_poller_bottom',        'setup.php');
+	api_plugin_register_hook('gridlimits', 'grid_menu',            'gridlimits_grid_menu',            'setup.php');
+
+	api_plugin_register_realm('gridlimits', 'grid_limits.php', 'LSF Limits', 1);
+
+	gridlimits_setup_table_new();
+}
+
+function gridlimits_poller_bottom() {
+	global $config;
+
+	include_once($config['base_path'] . '/plugins/grid/lib/grid_functions.php');
+
+	$command_string = read_config_option('path_php_binary');
+	$extra_args = '-q "' . $config['base_path'] . '/plugins/gridlimits/poller_gridlimits.php"';
+	exec_background($command_string, $extra_args);
+}
+
+function gridlimits_config_arrays() {
+	global $grid_menu, $config, $menu, $user_auth_realms, $user_auth_realm_filenames;
+
+	# $user_auth_realms["25'] = 'RTM -> Grid Limits';
+	$user_auth_realm_filenames['grid_limits.php'] = 25;
+
+	$grid_menu[__('Reports', 'grid')]['plugins/gridlimits/grid_limits.php'] = __('Limits', 'gridlimits');
+
+	if (function_exists('auth_augment_roles')) {
+        auth_augment_roles(__('LSF User', 'grid'), array('grid_limits.php'));
+	}
+}
+
+function plugin_gridlimits_version() {
+	global $config;
+	$info = parse_ini_file($config['base_path'] . '/plugins/gridlimits/INFO', true);
+	return $info['info'];
+}
+
+function plugin_gridlimits_uninstall() {
+	/* Do any extra Uninstall stuff here */
+	db_execute('DROP TABLE IF EXISTS grid_limits');
+	db_execute('DROP TABLE IF EXISTS grid_limits_usage');
+	db_execute('DROP TABLE IF EXISTS grid_limits_history');
+}
+
+function plugin_gridlimits_check_config() {
+	/* Here we will check to ensure everything is configured */
+	gridlimits_check_upgrade();
+	return true;
+}
+
+function plugin_gridlimits_upgrade() {
+	/* Here we will upgrade to the newest version */
+	gridlimits_check_upgrade();
+	return false;
+}
+
+function gridlimits_check_upgrade() {
+	if (!db_column_exists('grid_limits', 'job_dispatch_limit')) {
+		db_execute('ALTER TABLE grid_limits
+			ADD column job_dispatch_limit int(10) unsigned default NULL AFTER fwd_tasks_limit,
+			ADD column job_dispatch_limit_usage int(10) unsigned default NULL AFTER job_dispatch_limit,
+			ADD column job_dispatch_limit_limit int(10) unsigned default NULL AFTER job_dispatch_limit_usage,
+			ADD column ineligible char(2) DEFAULT NULL AFTER job_dispatch_limit_limit');
+
+		db_execute('ALTER TABLE grid_limits_usage
+			ADD column job_dispatch_limit_usage int(10) unsigned default NULL AFTER fwd_tasks_limit,
+			ADD column job_dispatch_limit_limit int(10) unsigned default NULL AFTER job_dispatch_limit_usage');
+	}
+}
+
+function gridlimits_check_dependencies() {
+	global $plugins, $config;
+	return true;
+}
+
+function gridlimits_setup_table_new() {
+	db_execute("CREATE TABLE IF NOT EXISTS grid_limits (
+		clusterid int(10) unsigned NOT NULL default '0',
+		limit_name varchar(100) NOT NULL,
+		users blob,
+		per_user blob,
+		hosts blob,
+		per_host blob,
+		queues blob,
+		per_queue blob,
+		projects blob,
+		per_project blob,
+		lic_projects blob,
+		per_lic_project blob,
+		clusters blob,
+		per_cluster blob,
+		apps blob,
+		per_app blob,
+		slots int(10) unsigned default NULL,
+		slots_usage int(10) unsigned default NULL,
+		slots_limit int(10) unsigned default NULL,
+		slots_per_processor varchar(1) default 'N',
+		mem int(10) unsigned default NULL,
+		mem_usage bigint unsigned default NULL,
+		mem_limit bigint unsigned default NULL,
+		mem_percent varchar(1) default 'N',
+		swp int(10) unsigned default NULL,
+		swp_usage bigint unsigned default NULL,
+		swp_limit bigint unsigned default NULL,
+		swp_percent varchar(1) default 'N',
+		tmp int(10) unsigned default NULL,
+		tmp_usage bigint unsigned default NULL,
+		tmp_limit bigint unsigned default NULL,
+		tmp_percent varchar(1) default 'N',
+		jobs int(10) unsigned default NULL,
+		jobs_usage int(10) unsigned default NULL,
+		jobs_limit int(10) unsigned default NULL,
+		resources blob,
+		resources_usage blob,
+		fwd_tasks int(10) unsigned default NULL,
+		fwd_tasks_usage int(10) unsigned default NULL,
+		fwd_tasks_limit int(10) unsigned default NULL,
+		job_dispatch_limit int(10) unsigned default NULL,
+		job_dispatch_limit_usage int(10) unsigned default NULL,
+		job_dispatch_limit_limit int(10) unsigned default NULL,
+		unit_for_limits varchar(5),
+		present int(10) unsigned default NULL,
+		last_updated timestamp NOT NULL default CURRENT_timestamp ON UPDATE CURRENT_timestamp,
+		PRIMARY KEY (clusterid, limit_name))
+		ENGINE=InnoDB
+		ROW_FORMAT=Dynamic");
+
+	db_execute("CREATE TABLE IF NOT EXISTS grid_limits_usage (
+		sequenceid bigint unsigned NOT NULL AUTO_INCREMENT,
+		clusterid int(10) unsigned NOT NULL default 0,
+		limit_name varchar(100) NOT NULL default '',
+		users blob,
+		queues blob,
+		hosts blob,
+		projects blob,
+		lic_projects blob,
+		clusters blob,
+		apps blob,
+		slots_usage int(10) unsigned default NULL,
+		slots_limit int(10) unsigned default NULL,
+		mem_usage bigint unsigned default NULL,
+		mem_limit bigint unsigned default NULL,
+		swp_usage bigint unsigned default NULL,
+		swp_limit bigint unsigned default NULL,
+		tmp_usage bigint unsigned default NULL,
+		tmp_limit bigint unsigned default NULL,
+		jobs_usage int(10) unsigned default NULL,
+		jobs_limit int(10) unsigned default NULL,
+		fwd_tasks_usage int(10) unsigned default NULL,
+		fwd_tasks_limit int(10) unsigned default NULL,
+		job_dispatch_limit_usage int(10) unsigned default NULL,
+		job_dispatch_limit_limit int(10) unsigned default NULL,
+		unit_for_limits varchar(5),
+		resources blob,
+		last_updated timestamp NOT NULL default CURRENT_timestamp ON UPDATE CURRENT_timestamp,
+		PRIMARY KEY (sequenceid),
+		INDEX clusterid_limit_name_last_updated(clusterid, limit_name, last_updated))
+		ENGINE=Aria
+		ROW_FORMAT=Dynamic");
+
+	db_execute("CREATE TABLE IF NOT EXISTS grid_limits_history (
+		sequenceid bigint unsigned NOT NULL default '0',
+		clusterid int(10) unsigned NOT NULL default '0',
+		limit_name varchar(100) NOT NULL default '',
+		users varchar(40) NOT NULL default '',
+		queues varchar(40) NOT NULL default '',
+		hosts varchar(64) NOT NULL default '',
+		projects varchar(100) NOT NULL default '',
+		lic_projects varchar(100) NOT NULL default '',
+		clusters varchar(20) NOT NULL default '',
+		apps varchar(20) NOT NULL default '',
+		slots_usage int(10) unsigned default NULL,
+		slots_limit int(10) unsigned default NULL,
+		mem_usage bigint unsigned default NULL,
+		mem_limit bigint unsigned default NULL,
+		swp_usage bigint unsigned default NULL,
+		swp_limit bigint unsigned default NULL,
+		tmp_usage bigint unsigned default NULL,
+		tmp_limit bigint unsigned default NULL,
+		jobs_usage int(10) unsigned default NULL,
+		jobs_limit int(10) unsigned default NULL,
+		fwd_tasks_usage int(10) unsigned default NULL,
+		fwd_tasks_limit int(10) unsigned default NULL,
+		unit_for_limits varchar(5),
+		resources blob,
+		last_seen timestamp DEFAULT '0000-00-00',
+		PRIMARY KEY (clusterid, limit_name, users, queues, hosts, projects, lic_projects, clusters, apps))
+		ENGINE=Aria
+		ROW_FORMAT=Dynamic");
+}
+
+function gridlimits_draw_navigation_text($nav) {
+	$nav['grid_limits.php:'] = array(
+		'title'   => __('Limits', 'gridlimits'),
+		'mapping' => '',
+		'url'     => 'grid_limits.php',
+		'level'   => '1'
+	);
+
+	$nav['grid_limits.php:'] = array(
+		'title'   => __('Limits Usage', 'gridlimits'),
+		'mapping' => 'grid_limits.php:',
+		'url'     => 'grid_limits.php',
+		'level'   => '2'
+	);
+
+	return $nav;
+}
+
+function gridlimits_grid_menu($grid_menu = array()) {
+	$menu = array(
+		__('Reports', 'grid') => array(
+			'plugins/gridlimits/grid_limits.php'  => __('Limits', 'gridlimits')
+		)
+	);
+
+	if (cacti_sizeof($grid_menu)) {
+		$menu2 = array();
+
+		foreach ($grid_menu as $gmkey => $gmval ) {
+			$menu2[$gmkey] = $gmval;
+			if ($gmkey == __('Reports', 'grid')) {
+				foreach($gmval as $key => $menu) {
+					$menu2[__('Reports', 'grid')][$key] = $menu;
+
+					if ($menu == __('Parameters', 'grid')) {
+						$menu2[__('Reports')]['plugins/gridlimits/grid_limits.php'] = __('Limits', 'gridlimits');
+					}
+				}
+			}
+		}
+
+		return $menu2;
+	}
+
+	return $menu;
+}


### PR DESCRIPTION
This plugin allows RTM users to see LSF limit's history for up-to two weeks for local cluster limits.  It does not support Global Limits at this time.

Signed-off-by: Larry Adams [thewitness@cacti.net](mailto:thewitness@cacti.net)
