### PR TITLE
Multiple enhancements to grid alarming

### DIFF
--- a/cacti/plugins/gridalarms/formats/alert.format
+++ b/cacti/plugins/gridalarms/formats/alert.format
@@ -1,6 +1,5 @@
 <html>
 <head>
-<!-- $Id$ -->
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <style type='text/css'>
 
@@ -91,6 +90,22 @@ td.tableSubHeaderColumn {
     padding: 3px;
     font-weight: bold;
     vertical-align: bottom;
+}
+
+.left {
+	text-align:left;
+}
+
+.right {
+	text-align: right;
+}
+
+.center {
+	text-align: center;
+}
+
+.nowrap {
+	white-space: nowrap;
 }
 
 </style>

--- a/cacti/plugins/gridalarms/gridalarms_alarm_edit.php
+++ b/cacti/plugins/gridalarms/gridalarms_alarm_edit.php
@@ -2,7 +2,7 @@
 // $Id$
 /*
  +-------------------------------------------------------------------------+
- | Copyright IBM Corp. 2006, 2024                                          |
+ | Copyright IBM Corp. 2006, 2025                                          |
  |                                                                         |
  | Licensed under the Apache License, Version 2.0 (the "License");         |
  | you may not use this file except in compliance with the License.        |
@@ -20,6 +20,7 @@
 
 chdir('../../');
 include_once('./include/auth.php');
+include_once('./lib/reports.php');
 include_once('./lib/utility.php');
 include_once('./plugins/gridalarms/lib/gridalarms_functions.php');
 
@@ -31,7 +32,7 @@ get_filter_request_var('alarm_id');
 
 if (isset_request_var('id')) {
 	if (get_request_var('id') > 0) {
-		if ( strpos(get_request_var('action'), 'check_' ) === false  ) {
+		if (strpos(get_request_var('action'), 'check_' ) === false) {
 			$gl_clusterid = db_fetch_cell_prepared('SELECT clusterid
 				FROM gridalarms_alarm
 				WHERE id = ?',
@@ -126,6 +127,10 @@ switch (get_request_var('action')) {
 		bottom_footer();
 
 		break;
+	case 'ajax_dnd';
+		layout_dnd();
+
+		break;
 	case 'layout_movedown':
 		layout_movedown();
 		header('Location: gridalarms_alarm_edit.php?header=false&tab=layout&id=' . get_request_var('id'));
@@ -210,8 +215,13 @@ switch (get_request_var('action')) {
 
 		$alarm = array();
 		$alarm['template_enabled'] = '';
+
 		if (!isempty_request_var('id')) {
 			$alarm = get_alarm_by_id(get_request_var('id'));
+
+			if (!isset($alarm['template_enabled'])) {
+				$alarm['template_enabled'] = '';
+			}
 		}
 
 		gridalarms_display_tabs($current_tab, $alarm['template_enabled']);
@@ -320,23 +330,25 @@ function check_sql_syntax($expression_id, $ajax = true) {
 	}
 }
 
-function check_script($expression_id, $type = 'thold', $ajax = true) {
+function get_script_command($id, $type) : string {
 	global $gl_clusterid, $gl_clustername;
-	if (!empty($expression_id)) {
+
+	$command = '';
+
+	if (!empty($id)) {
 		if ($type == 'thold') {
 			$command = trim(db_fetch_cell_prepared('SELECT script_thold
 				FROM gridalarms_expression
 				WHERE id = ?',
-				array($expression_id)), '; ');
+				array($id)), '; ');
 		} else {
 			$command = trim(db_fetch_cell_prepared('SELECT script_data
 				FROM gridalarms_expression
 				WHERE id = ?',
-				array($expression_id)), '; ');
+				array($id)), '; ');
 		}
 
-		$command = gridalarms_replace_custom_input($expression_id, $command);
-
+		$command = gridalarms_replace_custom_input($id, $command);
 		$command = str_replace('|alert_clusterid|', $gl_clusterid, $command);
 		$command = str_replace('|alert_clustername|', $gl_clustername, $command);
 
@@ -345,36 +357,44 @@ function check_script($expression_id, $type = 'thold', $ajax = true) {
 			WHERE name='path_webroot'");
 
 		$command = str_replace('|path_cacti|', $path_webroot, $command);
+	}
 
-		if (strlen($command)) {
-			$return_code = 0;
-			$output      = array();
-			$result      = exec($command, $output, $return_code);
+	return $command;
+}
 
-			if (strlen($result) && $return_code == 0) {
-				if (!$ajax) return true;
+function check_script($expression_id, $type = 'thold', $ajax = true) {
+	$command = get_script_command($expression_id, $type);
 
-				if ($type == 'thold') {
-					print "<p style='margin:5px 0px;min-height:15px' class='deviceUp'>" . __('OK', 'gridalarms') . '<br>' . __('Output: %s', trim(implode("\n", $output)), 'gridalarms') . '</p>';
-				} else{
-					print "<p style='margin:5px 0px;min-height:15px' class='deviceUp'>" . __('OK', 'gridalarms') . '<br>' . __('Output: %s', "<pre style='margin:0px;'>" . html_escape(trim(implode("\n", $output)) . '</pre>'), 'gridalarms') . '</p>';
-				}
+	if ($command != '') {
+		$return_code = 0;
+		$output      = array();
+		$result      = exec($command, $output, $return_code);
+		$output      = array_map('trim', $output);
+
+		if ($result != '' && $return_code == 0) {
+			if (!$ajax) {
+				return true;
+			}
+
+			if ($type == 'thold') {
+				print "<p style='margin:5px 0px;min-height:15px' class='deviceUp'>" . __('OK', 'gridalarms') . '<br>' . __('Output:', 'gridalarms') . html_escape(implode("\n", $output)) . '</p>';
 			} else {
-				if (!$ajax) return false;
-
-				if ($return_code == 127) {
-					print "<p style='margin:5px 0px;min-height:15px' class='deviceDown'>" . __('Error: Script File Not Found!', 'gridalarms') . '</p>';
-				} else {
-					if ($type == 'thold') {
-						print "<p style='margin:5px 0px;min-height:15px' class='deviceDown'>" . __('Error!', 'gridalarms') . '<br>' . __('Return Code: \'%s\'', $return_code, 'gridalarms') . '<br>' . __('Output %s', html_escape(trim(implode("\n", $output))), 'gridalarms') . '</p>';
-					} else{
-						print "<p style='margin:5px 0px;min-height:15px' class='deviceDown'>" . __('Error!', 'gridalarms') . '<br>' . __('Return Code: \'%s\'', $return_code, 'gridalarms') . '<br>' . __('Output: %s', "<pre style='margin:0px;'>" . html_escape(trim(implode("\n", $output))) . '</pre>', 'gridalarms') . '</p>';
-					}
-				}
+				print "<p style='margin:5px 0px;min-height:15px' class='deviceUp'>" . __('OK', 'gridalarms') . '<br>' . __('Output:', 'gridalarms') . '</p><pre style="margin:0px">' . html_escape(implode("\n", $output)) . '</pre>';
 			}
 		} else {
-			if (!$ajax) return false;
-			print "<p style='margin:5px 0px;min-height:15px' class='deviceDown'>" . __('No Command Defined, You must Save Alert First!', 'gridalarms') . '</p>';
+			if (!$ajax) {
+				return false;
+			}
+
+			if ($return_code == 127) {
+				print "<p style='margin:5px 0px;min-height:15px' class='deviceDown'>" . __('Error: Script File Not Found!', 'gridalarms') . '</p>';
+			} else {
+				if ($type == 'thold') {
+					print "<p style='margin:5px 0px;min-height:15px' class='deviceDown'>" . __('Error!', 'gridalarms') . '<br>' . __('Return Code: \'%s\'', $return_code, 'gridalarms') . '<br>' . __('Output: \'%s\'', html_escape(implode("\n", $output)), 'gridalarms') . '</p>';
+				} else{
+					print "<p style='margin:5px 0px;min-height:15px' class='deviceDown'>" . __('Error!', 'gridalarms') . '<br>' . __('Return Code: \'%s\'', $return_code, 'gridalarms') . '<br>' . __('Output: %s', "<pre style='margin:0px;'>" . html_escape(implode("\n", $output)) . '</pre>', 'gridalarms') . '</p>';
+				}
+			}
 		}
 	} else {
 		if (!$ajax) return false;
@@ -582,20 +602,31 @@ function draw_gridalarms_sql_preview($expression) {
 }
 
 function draw_gridalarms_script_preview($expression) {
+	$thold_command  = get_script_command($expression['id'], 'thold');
+	$output_command = get_script_command($expression['id'], 'data');
+
 	if (cacti_sizeof($expression)) { ?>
-	<tr class='even'>
-		<td id='syntax_message'><p style='margin:5px 0px;min-height:15px;'><?php print __('Not Run', 'gridalarms');?></p></td>
-	</tr>
-	<tr class='odd'>
-		<td>
-			<input id='check_script_threshold' type='button' name='check_script_threshold' value='<?php print __('Check Threshold Script', 'gridalarms');?>'/>
-			<input id='check_script_data' type='button' name='check_script_data' value='<?php print __('Check Items Script', 'gridalarms');?>'/>
-			<?php
-			print "<input type='hidden' id='check_syntax_expression_id' name='check_syntax_expression_id' value='" . $expression['id'] . "'/>";
-			?>
-		</td>
-	</tr>
-	<?php
+		<tr class='even'>
+			<td style='width: 50px'><b><?php print __('Thold:', 'gridalarms') . '</b>';?></td>
+			<td><?php print html_escape($thold_command);?></td>
+		</tr>
+		<tr class='even'>
+			<td style='width: 50px'><b><?php print __('Data:', 'gridalarms') . '</b>';?></td>
+			<td><?php print html_escape($output_command);?></td>
+		</tr>
+		<tr class='odd'>
+			<td colspan='2' style='padding:5px'>
+				<input id='check_script_threshold' type='button' name='check_script_threshold' value='<?php print __('Check Threshold Script', 'gridalarms');?>'/>
+				<input id='check_script_data' type='button' name='check_script_data' value='<?php print __('Check Items Script', 'gridalarms');?>'/>
+				<?php
+				print "<input type='hidden' id='check_syntax_expression_id' name='check_syntax_expression_id' value='" . $expression['id'] . "'/>";
+				?>
+			</td>
+		</tr>
+		<tr>
+			<td colspan='2' id='syntax_message'></td>
+		</tr>
+		<?php
 	}
 }
 
@@ -638,22 +669,25 @@ function form_save() {
 	get_filter_request_var('expression_id');
 	get_filter_request_var('id');
 	get_filter_request_var('template');
-	
-	$alarm_id = isempty_request_var('tab') ? get_request_var('alarm_id') : get_request_var('id');
-	if (!empty($alarm_id)) {
+
+	if (!isempty_request_var('id')) {
 		$oldalarm = db_fetch_row_prepared('SELECT base_time_display, alarm_type, frequency, alarm_fail_trigger, repeat_alert
 			FROM gridalarms_alarm
 			WHERE id = ?',
-			array($alarm_id));
-	
-		if ($oldalarm['base_time_display']!=get_request_var('base_time_display') || $oldalarm['alarm_type']!=get_request_var('alarm_type')
-		|| $oldalarm['frequency']!=get_request_var('frequency')
-		|| $oldalarm['alarm_fail_trigger']!=get_request_var('alarm_fail_trigger')
-		|| $oldalarm['repeat_alert']!=get_request_var('repeat_alert')) {
-			db_execute_prepared('UPDATE gridalarms_alarm
-				SET alarm_fail_count = 0
-				WHERE id = ?',
-				array($alarm_id));
+			array(get_request_var('id')));
+
+		if (cacti_sizeof($oldalarm)) {
+			if ($oldalarm['base_time_display'] != get_request_var('base_time_display') ||
+				$oldalarm['alarm_type'] != get_request_var('alarm_type') ||
+				$oldalarm['frequency'] != get_request_var('frequency') ||
+				$oldalarm['alarm_fail_trigger'] != get_request_var('alarm_fail_trigger') ||
+				$oldalarm['repeat_alert'] != get_request_var('repeat_alert')) {
+
+				db_execute_prepared('UPDATE gridalarms_alarm
+					SET alarm_fail_count = 0
+					WHERE id = ?',
+					array(get_request_var('id')));
+			}
 		}
 	}
 
@@ -681,14 +715,17 @@ function form_save() {
 		$save['script_thold']     = str_replace('"','\'',$save['script_thold']);
 		$save['script_data']      = str_replace('"','\'',$save['script_data']);
 
+		/* every save we reset the column data to be recalculated */
+		$save['column_data']      = '';
+
 		if (!is_error_message()) {
 			//Clean metrics cache when expression is modified/saved;
 			if (!isempty_request_var('id')) {
-				$expr_id = get_request_var('id');
+				$expr_id        = get_request_var('id');
 				$expression_old = get_expression_by_id($expr_id);
-				if (isset($_SESSION['sess_ga_expr']['expr_' . $expr_id])
-					&& ($expression_old['db_table'] != $save['db_table']
-						|| $expression_old['sql_query'] != $save['sql_query'])) {
+
+				if (isset($_SESSION['sess_ga_expr']['expr_' . $expr_id]) &&
+					($expression_old['db_table'] != $save['db_table'] || $expression_old['sql_query'] != $save['sql_query'])) {
 					unset($_SESSION['sess_ga_expr']['expr_' . $expr_id]);
 				}
 			}
@@ -831,6 +868,7 @@ function form_save() {
 		exit;
 	} elseif (isset_request_var('save_component_layout')) {
 		$save = array();
+
 		if (get_request_var('sequence') == '') {
 			$save['sequence'] = db_fetch_cell_prepared('SELECT max(sequence)+1
 				FROM gridalarms_alarm_layout
@@ -846,6 +884,11 @@ function form_save() {
 		$save['column_name']   = get_request_var('column_name');
 		$save['sortposition']  = get_request_var('sortposition');
 		$save['sortdirection'] = get_request_var('sortdirection');
+		$save['type']          = get_nfilter_request_var('type');
+		$save['units']         = get_nfilter_request_var('units');
+		$save['align']         = get_nfilter_request_var('align');
+		$save['digits']        = get_filter_request_var('digits');
+		$save['autoscale']     = get_filter_request_var('autoscale');
 
 		if (!is_error_message()) {
 			$id = sql_save($save, 'gridalarms_alarm_layout');
@@ -860,6 +903,7 @@ function form_save() {
 			}
 
 			raise_message(1);
+
 			header('Location: gridalarms_alarm_edit.php?header=false&tab=layout&id=' . get_request_var('alarm_id'));
 		} else {
 			header('Location: gridalarms_alarm_edit.php?header=false&action=layout_edit&id=' . get_request_var('alarm_id') . '&column=' . get_request_var('column_name'));
@@ -872,7 +916,9 @@ function form_save() {
 				if (isset_request_var('base_time_display')) {
 					if ( strtotime(get_request_var('base_time_display'))=== false ) {
 						raise_message('gridalarms_invalid_timestamp');
+
 						header('Location: gridalarms_alarm_edit.php?header=false&tab=' . (isset_request_var('tab') ? get_request_var('tab'):'general') . '&id=' . (isset($id) ? $id:get_request_var('id')));
+
 						exit;
 					}
 				}
@@ -889,14 +935,19 @@ function form_save() {
 				if (isset_request_var('base_time_display')) {
 					if ( strtotime(get_request_var('base_time_display'))=== false ) {
 						raise_message('gridalarms_invalid_timestamp');
+
 						header('Location: gridalarms_alarm_edit.php?header=false&tab=' . (isset_request_var('tab') ? get_request_var('tab'):'general') . '&id=' . (isset($id) ? $id:get_request_var('id')));
+
 						exit;
 					}
 				}
+
 				$id = push_out_template_to_alarm($_POST, 0);
+
 				template_propagation ("gridalarms_alarm", (isset($id) ? $id:get_request_var('id')));
 			}
-		} else {//at first create a instance based on a chosen template
+		} else {
+			/* at first create a instance based on a chosen template */
 			if (isset_request_var('base_time_display')) {
 				if ( strtotime(get_request_var('base_time_display'))=== false ) {
 					raise_message('gridalarms_invalid_timestamp');
@@ -910,9 +961,9 @@ function form_save() {
 				}
 			}
 
-			/*Only when a alert is created from a alert template, do the title replacement*/
+			/* only when a alert is created from a alert template, do the title replacement*/
 			if (get_request_var('template') > 0) {
-				if (do_title_replacement ($_POST) < 0) {
+				if (do_title_replacement($_POST) < 0) {
 					header('Location: gridalarms_alarm_edit.php?header=false&select_alert_template=1&action=select_template&template=' . get_request_var('template'));
 
 					exit;
@@ -920,6 +971,7 @@ function form_save() {
 			}
 
 			$id = push_out_template_to_alarm($_POST, isset_request_var('template') ? get_request_var('template'):0);
+
 			template_propagation ("gridalarms_alarm", (isset($id) ? $id:get_request_var('id')));
 		}
 
@@ -932,7 +984,7 @@ function form_save() {
 				array($id));
 		}
 
-		header('Location: gridalarms_alarm_edit.php?header=true&tab=' . (isset_request_var('tab') ? get_request_var('tab'):'general') . '&id=' . (isset($id) ? $id:get_request_var('id')));
+		header('Location: gridalarms_alarm_edit.php?tab=' . (isset_request_var('tab') ? get_request_var('tab'):'general') . '&id=' . (isset($id) ? $id:get_request_var('id')));
 
 		exit;
 	} elseif (isset_request_var('save_component_alarm')) {	//complete mode
@@ -945,11 +997,12 @@ function form_save() {
 
 			//push_out_template_to_alarm($_POST, get_request_var('template_id'), true);
 			template_propagation ('gridalarms_alarm', get_request_var('id'));
-			
+
 			$expr_id = db_fetch_cell_prepared('SELECT expression_id
-							FROM gridalarms_alarm
-							WHERE id = ?',
-							array(get_request_var('id')));
+				FROM gridalarms_alarm
+				WHERE id = ?',
+				array(get_request_var('id')));
+
 			if (isset($_SESSION['sess_ga_expr']['expr_' . $expr_id])) {
 				unset($_SESSION['sess_ga_expr']['expr_' . $expr_id]);
 			}
@@ -1070,7 +1123,15 @@ function form_save() {
 				// Syslog Severity/Priority and Facility
 				$save['syslog_priority']    = get_request_var('alarm_syslog_priority');
 				$save['syslog_facility']    = get_request_var('alarm_syslog_facility');
+
+				// Operator Notes
+				$save['notes']              = get_request_var('notes');
+				$save['external_id']        = get_request_var('external_id');
 			} else {
+				if (isset_request_var('format_file')) {
+					$save['format_file'] = get_nfilter_request_var('format_file');
+				}
+
 				if (trim(get_request_var('email_subject')) == '') {
 					$save['email_subject']  = __('ALERT: <NAME> Breached Threshold Limits', 'gridalarms');
 				} else {
@@ -1155,7 +1216,7 @@ function form_save() {
 				} else {
 					raise_message('gridalarms_alarm_save');
 				}
-			}elseif ($id && isempty_request_var('expression_id')) {
+			} elseif ($id && isempty_request_var('expression_id')) {
 				raise_message('gridalarms_alarm_save_nods');
 				header('Location: gridalarms_alarm_edit.php?header=false&tab=' . get_request_var('tab') . '&id=' . $id);
 				exit;
@@ -1391,13 +1452,13 @@ function confirm_layout_remove() {
 
 	html_start_box(__('Layout Column Remove', 'gridalarms'), '60%', '', '3', 'center', '');
 
-	$name = html_escape(get_nfilter_request_var('column'));
+	$name = html_escape_request_var('column');
 
 	print "<tr>
 		<td class='textArea'>
 			<p>" . __('Click \'Continue\' to Delete the following Layout Column <b>\'%s\'</b>.', $name, 'gridalarms') . "</p>
 		</td>
-	</tr>\n";
+	</tr>";
 
 	$cancel_url = html_escape('gridalarms_alarm_edit.php?action=edit&tab=layout&id=' . get_request_var('id'));
 
@@ -1407,7 +1468,7 @@ function confirm_layout_remove() {
 		<td class='saveRow'>
 			<input type='hidden' name='action' value='layout_remove'>
 			<input type='hidden' name='id' value='" . get_filter_request_var('id') . "'>
-			<input type='hidden' name='column' value='" . html_escape(get_nfilter_request_var('column')) . "'>
+			<input type='hidden' name='column' value='" . html_escape_request_var('column') . "'>
 			<input type='hidden' name='confirm_layout_remove' value='1'>
 			$save_html
 		</td>
@@ -1467,7 +1528,7 @@ function confirm_item_remove() {
 				<input type='hidden' name='confirm_item_remove' value='1'>
 				$save_html
 			</td>
-		</tr>\n";
+		</tr>";
 
 		html_end_box();
 	} elseif (get_nfilter_request_var('type') == 'input') {
@@ -1879,18 +1940,18 @@ function gridalarms_expression_edit() {
 
 				$move = '';
 				if ($i < $total_items) {
-					$move .= "<a class='pic fa fa-caret-down moveArrow' href='" . html_escape('gridalarms_alarm_edit.php?action=item_movedown&id=' . $item['id'] . '&expression_id=' . $expression['id'] . '&alarm_id=' . get_request_var('id')) . "'></a>";
+					$move .= "<a class='pic' href='" . html_escape('gridalarms_alarm_edit.php?action=item_movedown&id=' . $item['id'] . '&expression_id=' . $expression['id'] . '&alarm_id=' . get_request_var('id')) . "'><i class='fa fa-caret-down moveArrow'></i></a>";
 				} else {
-					$move .= '<span class="moveArrowNone"></span>';
+					$move .= '<i class="moveArrowNone"></i>';
 				}
 
 				if ($i > 1 && $i <= $total_items) {
-					$move .= "<a class='pic fa fa-caret-up moveArrow' href='" . html_escape('gridalarms_alarm_edit.php?action=item_moveup&id=' . $item['id'] . '&expression_id=' . $expression['id'] . '&alarm_id=' . get_request_var('id')) . "'></a>";
+					$move .= "<a class='pic' href='" . html_escape('gridalarms_alarm_edit.php?action=item_moveup&id=' . $item['id'] . '&expression_id=' . $expression['id'] . '&alarm_id=' . get_request_var('id')) . "'><i class='fa fa-caret-up moveArrow'></i></a>";
 				} else {
-					$move .= '<span class="moveArrowNone"></span>';
+					$move .= '<i class="moveArrowNone"></i>';
 				}
 
-				$move .= "<a class='pic fa fa-times deleteMarker' href='" . html_escape('gridalarms_alarm_edit.php?action=item_remove&id=' . $item['id'] . '&expression_id=' . $expression['id'] . '&type=expression' . '&alarm_id=' . get_request_var('id')) . "'></a>";
+				$move .= "<a class='pic' href='" . html_escape('gridalarms_alarm_edit.php?action=item_remove&id=' . $item['id'] . '&expression_id=' . $expression['id'] . '&type=expression' . '&alarm_id=' . get_request_var('id')) . "'><i class='fa fa-times deleteMarker'></i></a>";
 
 				form_selectable_cell($move, $item['id'], '', 'right');
 
@@ -1899,7 +1960,7 @@ function gridalarms_expression_edit() {
 				$i++;
 			}
 		} else {
-			echo "<tr><td colspan='4'><em>" . __('Data Source Items Found', 'gridalarms') . "</em></td></tr>";
+			print "<tr><td colspan='4'><em>" . __('Data Source Items Found', 'gridalarms') . '</em></td></tr>';
 		}
 
 		html_end_box();
@@ -1953,7 +2014,7 @@ function gridalarms_expression_edit() {
 				$i++;
 			}
 		} else {
-			echo "<tr><td colspan='6'><em>" . __('No Metrics Found', 'gridalarms') . "</em></td></tr>";
+			print "<tr><td colspan='6'><em>" . __('No Metrics Found', 'gridalarms') . '</em></td></tr>';
 		}
 
 		html_end_box();
@@ -2013,7 +2074,7 @@ function gridalarms_expression_edit() {
 				$i++;
 			}
 		} else {
-			echo "<tr><td colspan='5'><em>" . __('No Data Input Items Found', 'gridalarms') . "</em></td></tr>";
+			print "<tr><td colspan='5'><em>" . __('No Data Input Items Found', 'gridalarms') . '</em></td></tr>';
 		}
 
 		html_end_box();
@@ -2032,9 +2093,7 @@ function gridalarms_expression_edit() {
 			if (type_value != '') {
 				$('#type').val(type_value);
 				$.get('gridalarms_alarm_edit.php',{'action':'gettables', 'type': type_value}, function(data) {
-					$('#db_table').html(data).trigger('change').selectmenu('refresh');
-					// Get first visible option text and update the displayed text
-    					$("#db_table-button .ui-selectmenu-text").text($("#db_table option:selected").text()); 
+					$('select#db_table').empty().html(data);
 				});
 			}
 		});
@@ -2136,13 +2195,13 @@ function get_metric_type($db_table) {
 		return 1;
 	} elseif (isset($host_tables[$db_table])) {
 		return 2;
-	}elseif (isset($queue_tables[$db_table])) {
+	} elseif (isset($queue_tables[$db_table])) {
 		return 4;
-	}elseif (isset($user_tables[$db_table])) {
+	} elseif (isset($user_tables[$db_table])) {
 		return 8;
-	}elseif (isset($cluster_tables[$db_table])) {
+	} elseif (isset($cluster_tables[$db_table])) {
 		return 16;
-	}elseif (isset($license_tables[$db_table])) {
+	} elseif (isset($license_tables[$db_table])) {
 		return 32;
 	} else {
 		return 64;
@@ -2378,7 +2437,7 @@ function gridalarms_metric_edit() {
 			$('#row_db_table_display').hide();
 			$('#row_type').hide();
 			$('#row_type_display').hide();
-		}else if (ds_type == 2) {
+		} else if (ds_type == 2) {
 			$('#row_db_table').hide();
 			$('#row_db_table_display').hide();
 			$('#row_type').hide();
@@ -2468,7 +2527,7 @@ function get_metrics_for_alarm_form() {
 		$expression_metrics = get_metrics_from_cache_by_expression_id(get_request_var('expression_id'));
 
 		foreach($expression_metrics as $metric) {
-			print "<option value='" . $metric . "'>" . $metric . "</option>\n";
+			print "<option value='" . $metric . "'>" . $metric . '</option>';
 		}
 	}
 }
@@ -2497,7 +2556,7 @@ function alarm_save_contacts ($id, $contacts) {
 function format_expression_for_form($expressions) {
 	$result = array();
 	foreach ($expressions as $expression) {
-		$result[$expression["id"]] = $expression["name"];
+		$result[$expression['id']] = $expression['name'];
 	}
 	return $result;
 }
@@ -2506,7 +2565,7 @@ function gridalarms_display_tabs($current_tab, $template_enabled) {
 	global $config;
 
 	/* present a tabbed interface */
-	if ($template_enabled =="on") {
+	if ($template_enabled =='on') {
 		$tabs = array(
 			'general'  => __('General', 'gridalarms'),
 			'breached' => __('Breached Items', 'gridalarms')
@@ -2530,7 +2589,7 @@ function gridalarms_display_tabs($current_tab, $template_enabled) {
 					array(get_request_var('id')));
 			}
 
-			if ($dsid > 0 || get_nfilter_request_var('action') == 'expression_edit' || ($alarm['id'] > 0 && empty($alarm['expression_id'])) ) {
+			if ($dsid > 0 || get_nfilter_request_var('action') == 'expression_edit' || (cacti_sizeof($alarm) && $alarm['id'] > 0 && isset($alarm['expression_id']) && empty($alarm['expression_id']))) {
 				$tabs['data'] = __('Data Source', 'gridalarms');
 			}
 
@@ -2576,26 +2635,41 @@ function draw_simple_edit() {
 
 	include($config['base_path'] . '/plugins/gridalarms/includes/arrays.php');
 
+	$legacy_notification = read_config_option('thold_disable_legacy');
+
+	$not_users = array();
+	$users     = array();
+
+	$selected_users_where     = '';
+	$not_selected_users_where = '';
+	$send_notification_array  = array();
+
 	$users_custom_list = '';
 	$users_list        = '';
-	$send_notification_array = array();
 
 	if (isset_request_var('template')) {
 		$alarm = get_template_by_id(get_request_var('template'));
-		get_users_list(get_request_var('template'), 'template', $users_custom_list, $users_list, $send_notification_array);
-	}elseif (!isempty_request_var('id')) {
+
+		if ($legacy_notification == '') {
+			get_users_list(get_request_var('template'), 'template', $users_custom_list, $users_list, $send_notification_array);
+		}
+	} elseif (!isempty_request_var('id')) {
 		$alarm = get_alarm_by_id(get_request_var('id'));
-		get_users_list(get_request_var('id'), 'alarm', $users_custom_list, $users_list, $send_notification_array);
+
+		if ($legacy_notification == '') {
+			get_users_list(get_request_var('id'), 'alarm', $users_custom_list, $users_list, $send_notification_array);
+		}
 	} else {
 		$alarm = array();
 	}
-	//cacti_log("DEBUG: alarm is " . cacti_sizeof($alarm));
 
 	if (isset($alarm['notify_cluster_admin']) && $alarm['notify_cluster_admin'] == 1) {
 		$notify_cluster_admin = 'on';
 	} else {
 		$notify_cluster_admin = '';
 	}
+
+	$formats = reports_get_format_files();
 
 	if (cacti_sizeof($alarm)) {
 		/* unset the id so as to allow normal save logic to work */
@@ -2768,7 +2842,6 @@ function draw_simple_edit() {
 				'default' => 'off',
 				'value' => isset($alarm['req_ack']) ? $alarm['req_ack'] : ''
 			),
-			//end
 			'email_message_body' => array(
 				'friendly_name' => __('Email Settings', 'gridalarms'),
 				'method' => 'spacer',
@@ -2817,7 +2890,7 @@ function draw_simple_edit() {
 			)
 		);
 
-		if (read_config_option('gridalarm_disable_legacy') == '') {
+		if ($legacy_notification == '') {
 			$general_array += array(
 				'users' => array(
 					'friendly_name' => __('Notify Accounts', 'gridalarms'),
@@ -2906,9 +2979,7 @@ function draw_simple_edit() {
 			form_hidden_box('id', get_request_var('id'), '0');
 		}
 
-		if (isset_request_var('template')) {
-			form_hidden_box('template', get_request_var('template'), '0');
-		} else {
+		if (!isset_request_var('template')) {
 			form_hidden_box('template_id', $alarm['template_id'], '0');
 		}
 
@@ -2919,9 +2990,9 @@ function draw_simple_edit() {
 			form_save_button('gridalarms_alarm.php', 'save');
 		} else {
 			?>
-			<table style="width:100%;text-align:center;">
+			<table style='width:100%;text-align:center;'>
 				<tr>
-					<td class="saveRow">
+					<td class='saveRow'>
 						<input type='hidden' name='action' value='save'>
 						<input type='submit' value='<?php print __esc('Create', 'gridalarms');?>'>
 					</td>
@@ -2941,7 +3012,7 @@ function select_template() {
 	form_start('gridalarms_alarm_edit.php', 'chk');
 
 	?>
-	<div style="background-color:#f5f5f5; width:60%; margin-left:auto; margin-right:auto;">
+	<div style='background-color:#f5f5f5; width:60%; margin-left:auto; margin-right:auto;'>
 	<?php
 
 	$templates[-1] = __('None', 'gridalarms');
@@ -3020,7 +3091,7 @@ function select_template() {
 	bottom_footer();
 }
 
-function get_users_list($id, $type = 'alarm', &$users_custom_list = '', &$users_list = '', &$send_notification_array = array()) {
+function get_users_list($id, $type = 'alarm', &$users_custom_list, &$users_list, &$send_notification_array) {
 	$sql_params = array();
 
 	if ($type == 'alarm') {
@@ -3038,8 +3109,8 @@ function get_users_list($id, $type = 'alarm', &$users_custom_list = '', &$users_
 			SELECT contact_id
 			FROM gridalarms_alarm_contacts
 			WHERE alarm_id = ?)';
-		$sql_params[] = $id;
 
+		$sql_params[] = $id;
 	} else {
 		$alarm = db_fetch_row_prepared('SELECT *
 			FROM gridalarms_template
@@ -3055,6 +3126,7 @@ function get_users_list($id, $type = 'alarm', &$users_custom_list = '', &$users_
 			SELECT contact_id
 			FROM gridalarms_template_contacts
 			WHERE alarm_id = ?)';
+
 		$sql_params[] = $id;
 	}
 
@@ -3064,16 +3136,16 @@ function get_users_list($id, $type = 'alarm', &$users_custom_list = '', &$users_
 	$not_users = db_fetch_assoc_prepared("SELECT DISTINCT plugin_thold_contacts.id, plugin_thold_contacts.data,
 		plugin_thold_contacts.type, user_auth.full_name
 		FROM plugin_thold_contacts, user_auth
-		WHERE user_auth.id=plugin_thold_contacts.user_id
-		AND plugin_thold_contacts.data!='' $not_selected_users_where
+		WHERE user_auth.id = plugin_thold_contacts.user_id
+		AND plugin_thold_contacts.data != '' $not_selected_users_where
 		ORDER BY user_auth.full_name ASC, plugin_thold_contacts.type ASC", $sql_params);
 
 	if ($selected_users_where != '') {
 		$users = db_fetch_assoc_prepared("SELECT DISTINCT plugin_thold_contacts.id, plugin_thold_contacts.data,
 			plugin_thold_contacts.type, user_auth.full_name
 			FROM plugin_thold_contacts, user_auth
-			WHERE user_auth.id=plugin_thold_contacts.user_id
-			AND plugin_thold_contacts.data!=''
+			WHERE user_auth.id = plugin_thold_contacts.user_id
+			AND plugin_thold_contacts.data != ''
 			$selected_users_where
 			ORDER BY user_auth.full_name ASC, plugin_thold_contacts.type ASC", $sql_params);
 	} else {
@@ -3100,7 +3172,7 @@ function get_users_list($id, $type = 'alarm', &$users_custom_list = '', &$users_
 	if (cacti_sizeof($users)) {
 		foreach ($users as $users) {
 			$send_notification_array[$users['id']] = $users['full_name'] . ' - ' . ucfirst($users['type']);
-			$users_custom_list .= "<option value='". $users['id'] . "'>" . $users['full_name'] . " - " . ucfirst($users['type']) . " </option>";
+			$users_custom_list .= "<option value='". $users['id'] . "'>" . $users['full_name'] . ' - ' . ucfirst($users['type']) . ' </option>';
 			$users_list .= $users['id'] . ' ';
 		}
 	}
@@ -3108,49 +3180,57 @@ function get_users_list($id, $type = 'alarm', &$users_custom_list = '', &$users_
 	$users_custom_list .= '</select></td></tr></table>';
 }
 
-function draw_detailed_edit() {
-}
-
 function get_metrics_from_cache_by_expression_id($expression_id) {
 	if (isset($_SESSION['sess_ga_expr']['expr_' . $expression_id])){
 		$expression_metrics = $_SESSION['sess_ga_expr']['expr_' . $expression_id];
 	} else {
-		$expression_metrics = get_metrics_from_expression_by_id($expression_id);
+		$expression_metrics = get_template_metrics_from_expression_by_id($expression_id);
 		$_SESSION['sess_ga_expr']['expr_' . $expression_id] = $expression_metrics;
 	}
+
 	return $expression_metrics;
 }
 
 function edit_general_actions() {
 	global $config, $gridalarms_types, $alarm_types, $aggregation, $repeatarray, $alertarray, $timearray, $frequencies, $gridalarms_severities;
 
+	$legacy_notification = read_config_option('thold_disable_legacy');
+
+	$not_users = array();
+	$users     = array();
+
+	$selected_users_where     = '';
+	$not_selected_users_where = '';
+	$send_notification_array  = array();
+
 	$users_custom_list = '';
 	$users_list        = '';
-	$send_notification_array = array();
 
 	//Initial alarm-expr-metrics in session
-	if (!isset($_SESSION['sess_ga_expr'])){
+	if (!isset($_SESSION['sess_ga_expr'])) {
 		$_SESSION['sess_ga_expr'] = array();
 	}
 
 	if (!isempty_request_var('id')) {
 		$alarm = get_alarm_by_id(get_request_var('id'));
-		get_users_list(get_filter_request_var('id'), 'alarm', $users_custom_list, $users_list, $send_notification_array);
 
-		//Initial alarm-expr-metrics in session
-		if (!empty($alarm['expression_id'])
-			&& (!isset($_SERVER['HTTP_REFERER']) || strpos($_SERVER['HTTP_REFERER'], 'gridalarms_alarm.php') !== false
-				|| strpos($_SERVER['HTTP_REFERER'], 'grid_alarmdb.php') !== false)){
+		if ($legacy_notification == '') {
+			get_users_list(get_filter_request_var('id'), 'alarm', $users_custom_list, $users_list, $send_notification_array);
+		}
+
+		// Initial alarm-expr-metrics in session
+		if (!empty($alarm['expression_id']) &&
+			(!isset($_SERVER['HTTP_REFERER']) || strpos($_SERVER['HTTP_REFERER'], 'gridalarms_alarm.php') !== false || strpos($_SERVER['HTTP_REFERER'], 'grid_alarmdb.php') !== false)) {
 			$expr_id = $alarm['expression_id'];
+
 			if (isset($_SESSION['sess_ga_expr']['expr_' . $expr_id])){
 				unset($_SESSION['sess_ga_expr']['expr_' . $expr_id]);
 			}
 		}
 	} else {
-		// TODO: This is a security issue
 		$alarm = $_POST;
 
-		if (!isempty_request_var('id')) {    // id must be > 0
+		if (!isempty_request_var('id') && $legacy_notification == '') {
 			get_users_list(get_request_var('id'), 'alarm', $users_custom_list, $users_list, $send_notification_array);
 		}
 	}
@@ -3186,13 +3266,15 @@ function edit_general_actions() {
 	$expression_metrics = array();
 	$expression_desc    = '';
 	$expression_ds      = -1;
+
 	if (!empty($alarm['expression_id'])) {
 		$expression_id   = $alarm['expression_id'];
 		$expression      = get_expression_by_id($alarm['expression_id']);
 		$expression_desc = $expression['name'];
 		$expression_ds   = $expression['ds_type'];
-		//Query metrics for 'non-Script-DS'(PDB#235497) under 'General' tab
-		if($expression_ds != 2 && get_request_var('tab') == 'general'){
+
+		/* query metrics for 'non-Script-DS'(PDB#235497) under 'General' tab */
+		if ($expression_ds != 2 && get_request_var('tab') == 'general'){
 			$expression_metrics = get_metrics_from_cache_by_expression_id($expression_id);
 		}
 	}
@@ -3203,7 +3285,16 @@ function edit_general_actions() {
 		$notify_cluster_admin = '';
 	}
 
-	if (function_exists('define_syslog_variables')) define_syslog_variables();
+	if (!db_column_exists('gridalarms_alarm', 'format_file')) {
+		db_execute('ALTER TABLE gridalarms_alarm
+			ADD COLUMN format_file varchar(255) NOT NULL default "" AFTER email_subject');
+	}
+
+	if (function_exists('define_syslog_variables')) {
+		define_syslog_variables();
+	}
+
+	$formats = reports_get_format_files();
 
 	$general_array = array(
 		'template_header' => array(
@@ -3412,6 +3503,24 @@ function edit_general_actions() {
 			'method' => 'hidden',
 			'default' => read_config_option('gridalarm_facility'),
 			'value' => isset($alarm['syslog_facility']) ? $alarm['syslog_facility'] : ''
+		),
+		'external_id' => array(
+			'friendly_name' => __('External ID', 'gridalarms'),
+			'method' => 'textbox',
+			'max_length' => 20,
+			'size' => 20,
+			'default' => '',
+			'description' => __('An External ID used to classify this Alert Template.', 'gridalarms'),
+			'value' => isset($alarm_item_data['external_id']) ? $alarm_item_data['external_id'] : ''
+		),
+		'notes' => array(
+			'friendly_name' => __('Operator Notes', 'gridalarms'),
+			'description' => __('Enter instructions here for an operator who may be receiving the Alert message.', 'gridalarms'),
+			'method' => 'textarea',
+			'class' => 'textAreaNotes',
+			'textarea_rows' => '4',
+			'textarea_cols' => '60',
+			'value' => isset($alarm_item_data['notes']) ? $alarm_item_data['notes'] : ''
 		)
 	);
 
@@ -3467,7 +3576,7 @@ function edit_general_actions() {
         )
 	);
 
-	if (read_config_option('gridalarm_disable_legacy') == '') {
+	if ($legacy_notification == '') {
 		$actions_array += array(
 			'users' => array(
 				'friendly_name' => __('Notify Accounts', 'gridalarms'),
@@ -3671,18 +3780,70 @@ function layout_edit() {
 	</script>
 	<?php
 
+	if (read_config_option('drag_and_drop') == 'on') { ?>
+	<script type='text/javascript'>
+	$(function() {
+		$('#gridalarms_alarm_edit_edit1_child').attr('id', 'layout').find('tr:first-child').addClass('nodrag');
+		$('#layout').tableDnD({
+			onDrop: function(table, row) {
+				loadPageNoHeader('gridalarms_alarm_edit.php?action=ajax_dnd&id=<?php isset_request_var('id') ? print get_request_var('id') : print 0;?>&'+$.tableDnD.serialize());
+			}
+		});
+	});
+	</script>
+	<?php }
+
 	$arl_caption_tip = __('Alert Report Layout', 'gridalarms') . '<div class="formTooltip">' . display_tooltip(__('Change your layout if you want to have different columns: <ul><li>For Job drill down -  include the following columns: clusterid, jobid, indexid, and submit_time.</li><li>For Queue or User drill down -  include the clusterid column and either the Queue, Queuename, or User columns.</li><li>For Host drill down -  include the clusterid column and either the Exec Host, Host, or From Host columns. </li></ul>If you have included clusterid column in your SQL queries and Tables, then you can also select the cluster name column. Note that the sort does not work unless the cluster name column is returned in the SQL Query.', 'gridalarms')) . '</div>';
 	html_start_box($arl_caption_tip, '100%', '', '3', 'center', 'gridalarms_alarm_edit.php?action=layout_add&id=' . get_request_var('id'));
 
 	$display_text = array(
-		__('Item Number', 'gridalarms'),
-		__('Display Name', 'gridalarms'),
-		__('Column Name', 'gridalarms'),
-		__('Sort Column', 'gridalarms'),
-		__('Sort Order', 'gridalarms')
+		array(
+			'display' => __('Item Number', 'gridalarms'),
+			'align'   => 'left',
+		),
+		array(
+			'display' => __('Display Name', 'gridalarms'),
+			'align'   => 'left',
+		),
+		array(
+			'display' => __('Column Name', 'gridalarms'),
+			'align'   => 'left',
+		),
+		array(
+			'display' => __('Type', 'gridalarms'),
+			'align'   => 'left',
+		),
+		array(
+			'display' => __('Align', 'gridalarms'),
+			'align'   => 'left',
+		),
+		array(
+			'display' => __('Units', 'gridalarms'),
+			'align'   => 'left'
+		),
+		array(
+			'display' => __('Round Value', 'gridalarms'),
+			'align'   => 'left'
+		),
+		array(
+			'display' => __('Auto Scale', 'gridalarms'),
+			'align'   => 'left'
+		),
+		array(
+			'display' => __('Sort Column', 'gridalarms'),
+			'align'   => 'left',
+		),
+		array(
+			'display' => __('Sort Order', 'gridalarms'),
+			'align'   => 'left',
+		),
+		array(
+			'display' => __('Actions', 'gridalarms'),
+			'align'   => 'right',
+		)
 	);
 
-	html_header($display_text, 2);
+	html_header($display_text, 1);
 
 	$items = db_fetch_assoc_prepared('SELECT *
 		FROM gridalarms_alarm_layout
@@ -3704,30 +3865,54 @@ function layout_edit() {
 	$total_items = cacti_sizeof($items);
 	if ($total_items) {
 		foreach ($items as $item) {
-			form_alternate_row();
+			form_alternate_row('line' . $item['id']);
+
+			if ($item['align'] == '') {
+				$item['align'] = 'left';
+			}
+
+			if ($item['type'] == '') {
+				$item['type'] = 'general';
+			}
 
 			form_selectable_cell(filter_value(__('Item #%d', $i, 'gridalarms'), '', 'gridalarms_alarm_edit.php?action=layout_edit&id=' . get_request_var('id') . '&column=' . $item['column_name']), $item['alarm_id'], '', '');
 			form_selectable_cell('<em>' . html_escape($item['display_name']) . '</em>', $item['alarm_id']);
 			form_selectable_cell(html_escape($item['column_name']), $item['alarm_id']);
-			form_selectable_cell(($item['sortposition'] > 0 ? $item['sortposition']:__('N/A', 'gridalarms')), $item['alarm_id']);
-			form_selectable_cell(($item['sortposition'] > 0 ? ($item['sortdirection'] == 0 ? __('Ascending', 'gridalarms'):__('Descending', 'gridalarms')):__('N/A', 'gridalarms')), $item['alarm_id']);
+			form_selectable_cell(ucwords($item['type']), $item['id']);
+			form_selectable_cell(ucwords($item['align']), $item['id']);
 
-            $move = '';
-            if ($i < $total_items) {
-                $move .= "<a class='pic fa fa-caret-down moveArrow' href='" . html_escape('gridalarms_alarm_edit.php?action=layout_movedown&id=' . get_request_var('id') . '&column=' . $item['column_name']) . "'></a>";
-            } else {
-                $move .= '<span class="moveArrowNone"></span>';
-            }
+			if ($item['type'] == 'integer' || $item['type'] == 'double' || $item['type'] == 'general') {
+				form_selectable_cell(ucwords($item['units']), $item['id']);
+				form_selectable_cell($item['digits'] >= 0 ? $item['digits']:__('Auto', 'gridalarms'), $item['id'], '', 'left');
+				form_selectable_cell($item['autoscale'] == 0 ? __('Yes', 'gridalarms'):__('No', 'gridalarms'), $item['id'], '', 'left');
+			} else {
+				form_selectable_cell(__('-', 'gridalarms'), $item['id']);
+				form_selectable_cell(__('-', 'gridalarms'), $item['id'], '', 'left');
+				form_selectable_cell(__('-', 'gridalarms'), $item['id'], '', 'left');
+			}
 
-            if ($i > 1 && $i <= $total_items) {
-                $move .= "<a class='pic fa fa-caret-up moveArrow' href='" . html_escape('gridalarms_alarm_edit.php?action=layout_moveup&id=' . get_request_var('id') . '&column=' . $item['column_name']) . "'></a>";
-            } else {
-                $move .= '<span class="moveArrowNone"></span>';
-            }
+			form_selectable_cell(($item['sortposition'] > 0 ? $item['sortposition']:__('N/A', 'gridalarms')), $item['alarm_id'], '', 'left');
+			form_selectable_cell(($item['sortposition'] > 0 ? ($item['sortdirection'] == 0 ? __('Ascending', 'gridalarms'):__('Descending', 'gridalarms')):__('N/A', 'gridalarms')), $item['alarm_id'], '', 'left');
 
-            $move .= "<a class='pic fa fa-times deleteMarker' href='" . html_escape('gridalarms_alarm_edit.php?action=layout_remove&id=' . get_request_var('id') . '&column=' . $item['column_name']) . "'></a>";
+			$move = '';
 
-            form_selectable_cell($move, $item['id'], '', 'right');
+			if (read_config_option('drag_and_drop') != 'on') {
+				if ($i < $total_items) {
+					$move .= "<a class='pic fa fa-caret-down moveArrow' href='" . html_escape('gridalarms_alarm_edit.php?action=layout_movedown&id=' . get_request_var('id') . '&column=' . $item['column_name']) . "'></a>";
+				} else {
+					$move .= '<span class="moveArrowNone"></span>';
+				}
+
+				if ($i > 1 && $i <= $total_items) {
+					$move .= "<a class='pic fa fa-caret-up moveArrow' href='" . html_escape('gridalarms_alarm_edit.php?action=layout_moveup&id=' . get_request_var('id') . '&column=' . $item['column_name']) . "'></a>";
+				} else {
+					$move .= '<span class="moveArrowNone"></span>';
+				}
+			}
+
+			$move .= "<a class='pic fa fa-times deleteMarker' href='" . html_escape('gridalarms_alarm_edit.php?action=layout_remove&id=' . get_request_var('id') . '&column=' . $item['column_name']) . "'></a>";
+
+			form_selectable_cell($move, $item['id'], '', 'right');
 
 			form_end_row();
 
@@ -3738,6 +3923,37 @@ function layout_edit() {
 	}
 
 	html_end_box();
+}
+
+function layout_dnd() {
+	/* ================= Input validation ================= */
+	get_filter_request_var('id');
+	/* ================= Input validation ================= */
+
+	$continue = true;
+
+	if (isset_request_var('layout') && is_array(get_nfilter_request_var('layout'))) {
+		$layouts = get_nfilter_request_var('layout');
+
+		if (cacti_sizeof($layouts)) {
+			$sequence = 1;
+			foreach($layouts as $layout) {
+				$layout = str_replace('line', '', $layout);
+
+				input_validate_input_number($layout);
+
+				db_execute_prepared('UPDATE gridalarms_alarm_layout
+					SET sequence = ?
+					WHERE id = ?
+					AND alarm_id = ?',
+					array($sequence, $layout, get_request_var('id')));
+
+				$sequence++;
+			}
+		}
+	}
+
+	header('Location: gridalarms_alarm_edit.php?action=edit&tab=layout&header=false&id=' . get_request_var('id'));
 }
 
 function layout_movedown() {
@@ -3847,7 +4063,13 @@ function layout_item_edit($new = false) {
 			'column_name', 'column_name'
 		);
 
-		$available_columns = get_metrics_from_expression_by_alarm_id(get_request_var('id'));
+		$expression = get_expression_by_alarm_id(get_request_var('id'));
+
+		if ($expression['ds_type'] == 0) {
+			$available_columns = get_table_columns($expression['db_table']);
+		} else {
+			$available_columns = get_columns_from_sql($expression['sql_query'], 'alarm', get_request_var('id'));
+		}
 
 		if (isset($available_columns['clusterid'])) {
 			$available_columns['clustername'] = 'clustername';
@@ -3871,6 +4093,11 @@ function layout_item_edit($new = false) {
 	html_start_box(__('Layout Item', 'gridalarms'), '100%', '', '3', 'center', '');
 
 	$layout_items_array = array(
+		'spacer0' => array(
+			'method' => 'spacer',
+			'friendly_name' => __('General Settings', 'gridalarms'),
+			'collapsible' => false
+		),
 		'display_name' => array(
 			'friendly_name' => __('Display Name', 'gridalarms'),
 			'description' => __('The name that is displayed in all reports.', 'gridalarms'),
@@ -3906,6 +4133,88 @@ function layout_item_edit($new = false) {
 	}
 
 	$layout_items_array += array(
+		'spacer1' => array(
+			'method' => 'spacer',
+			'friendly_name' => __('Display/Alignment Settings', 'gridalarms'),
+			'collapsible' => true
+		),
+		'type' => array(
+			'friendly_name' => __('Column Type', 'gridalarms'),
+			'method' => 'drop_array',
+			'array' => array(
+				'general'  => __('General', 'gridalarms'),
+				'string'   => __('String', 'gridalarms'),
+				'integer'  => __('Integer', 'gridalarms'),
+				'double'   => __('Double', 'gridalarms'),
+				'fpercent' => __('Percent Fractional (1 = 100%%)', 'gridalarms'),
+				'wpercent' => __('Percent Whole (100 = 100%%)', 'gridalarms'),
+				'date'     => __('Date', 'gridalarms'),
+			),
+			'description' => __('Select the Column Type.  When doing so Grid Alerts will provide additional options for formatting.', 'gridalarms'),
+			'value' => isset($layout['type'] ) ? $layout['type']  : ''
+		),
+		'units' => array(
+			'friendly_name' => __('Display Units', 'gridalarms'),
+			'method' => 'drop_array',
+			'array' => array(
+				'none'    => __('None', 'gridalarms'),
+				'bytes'   => __('Bytes', 'gridalarms'),
+				'kbytes'  => __('Kilo Bytes', 'gridalarms'),
+				'mbytes'  => __('Mega Bytes', 'gridalarms'),
+				'gbytes'  => __('Giga Bytes', 'gridalarms'),
+				'tbytes'  => __('Tera Bytes', 'gridalarms'),
+				'pbytes'  => __('Peta Bytes', 'gridalarms'),
+				'xbytes'  => __('Exa Bytes', 'gridalarms'),
+				'jobs'    => __('Jobs', 'gridalarms'),
+				'slots'   => __('Slots', 'gridalarms'),
+				'seconds' => __('Seconds', 'gridalarms'),
+				'minutes' => __('Minutes', 'gridalarms'),
+				'hours'   => __('Hours', 'gridalarms'),
+				'days'    => __('Days', 'gridalarms'),
+			),
+			'description' => __('Select the number of unit type to assist in formatting the output of the Column.', 'gridalarms'),
+			'value' => isset($layout['units']) ? $layout['units']: 'none'
+		),
+		'align' => array(
+			'friendly_name' => __('Column Alignment', 'gridalarms'),
+			'method' => 'drop_array',
+			'array' => array(
+				'left'   => __('Left', 'gridalarms'),
+				'right'  => __('Right', 'gridlarms'),
+				'center' => __('Center', 'gridalarms'),
+			),
+			'description' => __('Select the desired alignment for this Column.', 'gridalarms'),
+			'value' => isset($layout['align']) ? $layout['align']: 'left'
+		),
+		'digits' => array(
+			'friendly_name' => __('Significant Digits', 'gridalarms'),
+			'method' => 'drop_array',
+			'array' => array(
+				'-1' => __('Auto', 'gridalarms'),
+				'0'  => __('%s Digits', 0, 'gridalarms'),
+				'1'  => __('%s Digits', 1, 'gridlarms'),
+				'2'  => __('%s Digits', 2, 'gridalarms'),
+				'3'  => __('%s Digits', 3, 'gridalarms'),
+				'4'  => __('%s Digits', 4, 'gridalarms'),
+			),
+			'description' => __('Select the number of of Significant Digits for numeric display formats.', 'gridalarms'),
+			'value' => isset($layout['digits']) ? $layout['digits']: '0'
+		),
+		'autoscale' => array(
+			'friendly_name' => __('Auto Scale', 'gridalarms'),
+			'method' => 'drop_array',
+			'array' => array(
+				'0'  => __('Yes', 'gridalarms'),
+				'1'  => __('No', 'gridlarms'),
+			),
+			'description' => __('Select the if you wish to Autoscale the numeric data from its base unit.', 'gridalarms'),
+			'value' => isset($layout['autoscale']) ? $layout['autoscale']: '0'
+		),
+		'spacer2' => array(
+			'method' => 'spacer',
+			'friendly_name' => __('Sort Settings', 'gridalarms'),
+			'collapsible' => true
+		),
 		'sortposition' => array(
 			'friendly_name' => __('Sort Order', 'gridalarms'),
 			'description' => __('Select the desired sort order for this column. You can have up to four order variables. The order that is selected pushes down equal or lower valued sort columns.', 'gridalarms'),
@@ -3943,9 +4252,50 @@ function layout_item_edit($new = false) {
 	form_hidden_box('alarm_id', (isset_request_var('id') ? get_request_var('id') : '0'), '');
 	form_hidden_box('sequence', (isset($layout['sequence']) ? $layout['sequence'] : ''), '');
 
+	if (!$new) {
+		form_hidden_box('column_name', $layout['column_name'], '');
+	}
+
 	form_hidden_box('save_component_layout', '1', '');
 
 	html_end_box();
 
 	form_save_button('gridalarms_alarm_edit.php?tab=layout&id=' . get_request_var('id'));
+
+	?>
+	<script type='text/javascript'>
+	$(function() {
+		$('#type').change(function() {
+			changeType();
+		});
+
+		changeType();
+	});
+
+	function changeType() {
+		switch ($('#type').val()) {
+			case 'general':
+			case 'date':
+			case '':
+			case 'integer':
+			case 'double':
+				$('#row_units').show();
+				$('#row_digits').show();
+				$('#row_autoscale').show();
+				break;
+			case 'fpercent':
+			case 'wpercent':
+				$('#row_units').hide();
+				$('#row_digits').show();
+				$('#row_autoscale').show();
+				break;
+			case 'string':
+				$('#row_units').hide();
+				$('#row_digits').hide();
+				$('#row_autoscale').hide();
+				break;
+		}
+	}
+	</script>
+	<?php
 }

--- a/cacti/plugins/gridalarms/includes/database.php
+++ b/cacti/plugins/gridalarms/includes/database.php
@@ -2,7 +2,7 @@
 // $Id$
 /*
  +-------------------------------------------------------------------------+
- | Copyright IBM Corp. 2006, 2022                                          |
+ | Copyright IBM Corp. 2006, 2025                                          |
  |                                                                         |
  | Licensed under the Apache License, Version 2.0 (the "License");         |
  | you may not use this file except in compliance with the License.        |
@@ -67,6 +67,9 @@ function gridalarms_setup_new_tables() {
 	$data['columns'][] = array('name' => 'req_ack', 'type' => 'char(3)', 'NULL' => false, 'default' => 'off');
 	$data['columns'][] = array('name' => 'email_body', 'type' => 'text', 'NULL' => false);
 	$data['columns'][] = array('name' => 'email_subject', 'type' => 'text', 'NULL' => false);
+	$data['columns'][] = array('name' => 'format_file', 'type' => 'varchar(255)', 'NULL' => false, 'default' => '');
+	$data['columns'][] = array('name' => 'notes', 'type' => 'text', 'NULL' => true);
+	$data['columns'][] = array('name' => 'external_id', 'type' => 'varchar(40)', 'NULL' => false, 'default' => '');
 	$data['primary'] = 'id';
 	$data['keys'][] = array('name' => 'alarm_enabled', 'columns' => 'alarm_enabled');
 	$data['keys'][] = array('name' => 'clusterid', 'columns' => 'clusterid');
@@ -84,7 +87,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'contact_id', 'columns' => 'contact_id');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Alert contacts similar to Thold';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_alarm_contacts', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_alarm_contacts', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => false, 'auto_increment' => true);
@@ -95,10 +98,15 @@ function gridalarms_setup_new_tables() {
 	$data['columns'][] = array('name' => 'sequence', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => false, 'default' => '1');
 	$data['columns'][] = array('name' => 'sortposition', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => true);
 	$data['columns'][] = array('name' => 'sortdirection', 'unsigned' => true, 'type' => 'int(1)', 'NULL' => true);
+	$data['columns'][] = array('name' => 'type', 'type' => 'varchar(10)', 'NULL' => false, 'default' => '');
+	$data['columns'][] = array('name' => 'units', 'type' => 'varchar(10)', 'NULL' => false, 'default' => '');
+	$data['columns'][] = array('name' => 'align', 'type' => 'varchar(10)', 'NULL' => false, 'default' => '');
+	$data['columns'][] = array('name' => 'digits', 'type' => 'tinyint(4)', 'NULL' => false, 'default' => '-1');
+	$data['columns'][] = array('name' => 'autoscale', 'type' => 'tinyint(4)', 'NULL' => false, 'default' => '0');
 	$data['primary'] = 'id';
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Report Layout Data for Alert Tablular Reports';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_alarm_layout', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_alarm_layout', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'bigint(20)', 'NULL' => false, 'auto_increment' => true);
@@ -117,7 +125,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'type', 'columns' => 'type');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Alert Logs';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_alarm_log', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_alarm_log', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => false, 'auto_increment' => true);
@@ -162,7 +170,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'alarm_id_present', 'columns' => 'alarm_id`,`present');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores an Archive of Alert Tabular Details';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_alarm_log_items', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_alarm_log_items', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => false, 'auto_increment' => true);
@@ -180,7 +188,7 @@ function gridalarms_setup_new_tables() {
 	$data['primary'] = 'id';
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Alert Expression Details';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_expression', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_expression', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'mediumint(8)', 'NULL' => false, 'auto_increment' => true);
@@ -194,7 +202,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'exp_id_name', 'columns' => 'expression_id`,`name');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Custom Input Variables and Defaults for Expressions';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_expression_input', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_expression_input', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'mediumint(8)', 'NULL' => false, 'auto_increment' => true);
@@ -208,7 +216,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'expression_id', 'columns' => 'expression_id');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = '';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_expression_item', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_expression_item', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => false, 'auto_increment' => true);
@@ -222,7 +230,7 @@ function gridalarms_setup_new_tables() {
 	$data['row_format'] = 'DYNAMIC';
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Metrics to be watched for Legacy Expressions';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_metric', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_metric', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'expression_id', 'unsigned' => true, 'type' => 'mediumint(8)', 'NULL' => false, 'default' => '0');
@@ -230,7 +238,7 @@ function gridalarms_setup_new_tables() {
 	$data['primary'] = 'expression_id`,`metric_id';
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Table Linking Metrics to Expressions';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_metric_expression', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_metric_expression', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'type' => 'int(11)', 'NULL' => false, 'auto_increment' => true);
@@ -272,6 +280,9 @@ function gridalarms_setup_new_tables() {
 	$data['columns'][] = array('name' => 'req_ack', 'type' => 'char(3)', 'NULL' => false, 'default' => 'off');
 	$data['columns'][] = array('name' => 'email_body', 'type' => 'text', 'NULL' => false);
 	$data['columns'][] = array('name' => 'email_subject', 'type' => 'text', 'NULL' => false);
+	$data['columns'][] = array('name' => 'format_file', 'type' => 'varchar(255)', 'NULL' => false, 'default' => '');
+	$data['columns'][] = array('name' => 'notes', 'type' => 'text', 'NULL' => true);
+	$data['columns'][] = array('name' => 'external_id', 'type' => 'varchar(40)', 'NULL' => false, 'default' => '');
 	$data['primary'] = 'id';
 	$data['keys'][] = array('name' => 'hash', 'columns' => 'hash');
 	$data['keys'][] = array('name' => 'notify_alert', 'columns' => 'notify_alert');
@@ -279,7 +290,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'tcheck', 'columns' => 'tcheck');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Alert Template definitions similar to Thold';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_template', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_template', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'alarm_id', 'type' => 'int(12)', 'NULL' => false);
@@ -288,7 +299,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'contact_id', 'columns' => 'contact_id');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Alert Template Contacts similar to Thold';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_template_contacts', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_template_contacts', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => false, 'auto_increment' => true);
@@ -306,7 +317,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'hash', 'columns' => 'hash');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Alert Template Expressions';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_template_expression', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_template_expression', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'mediumint(8)', 'NULL' => false, 'auto_increment' => true);
@@ -320,7 +331,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'hash', 'columns' => 'hash');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = 'Stores Alert Template Custom Data Inputs and Defaults';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_template_expression_input', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_template_expression_input', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'mediumint(8)', 'NULL' => false, 'auto_increment' => true);
@@ -334,7 +345,7 @@ function gridalarms_setup_new_tables() {
 	$data['keys'][] = array('name' => 'expression_id', 'columns' => 'expression_id');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = '';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_template_expression_item', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_template_expression_item', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => false, 'auto_increment' => true);
@@ -345,11 +356,16 @@ function gridalarms_setup_new_tables() {
 	$data['columns'][] = array('name' => 'sequence', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => false, 'default' => '1');
 	$data['columns'][] = array('name' => 'sortposition', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => true);
 	$data['columns'][] = array('name' => 'sortdirection', 'unsigned' => true, 'type' => 'int(1)', 'NULL' => true);
+	$data['columns'][] = array('name' => 'type', 'type' => 'varchar(10)', 'NULL' => false, 'default' => '');
+	$data['columns'][] = array('name' => 'units', 'type' => 'varchar(10)', 'NULL' => false, 'default' => '');
+	$data['columns'][] = array('name' => 'align', 'type' => 'varchar(10)', 'NULL' => false, 'default' => '');
+	$data['columns'][] = array('name' => 'digits', 'type' => 'tinyint(4)', 'NULL' => false, 'default' => '-1');
+	$data['columns'][] = array('name' => 'autoscale', 'type' => 'tinyint(4)', 'NULL' => false, 'default' => '0');
 	$data['primary'] = 'id';
 	$data['keys'][] = array('name' => 'hash', 'columns' => 'hash');
 	$data['type'] = 'InnoDB';
 	$data['comment'] = '';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_template_layout', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_template_layout', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'id', 'unsigned' => true, 'type' => 'int(10)', 'NULL' => false, 'auto_increment' => true);
@@ -365,7 +381,7 @@ function gridalarms_setup_new_tables() {
 	$data['row_format'] = 'DYNAMIC';
 	$data['type'] = 'InnoDB';
 	$data['comment'] = '';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_template_metric', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_template_metric', $data);
 
 	$data = array();
 	$data['columns'][] = array('name' => 'expression_id', 'unsigned' => true, 'type' => 'mediumint(8)', 'NULL' => false, 'default' => '0');
@@ -373,7 +389,7 @@ function gridalarms_setup_new_tables() {
 	$data['primary'] = 'expression_id`,`metric_id';
 	$data['type'] = 'InnoDB';
 	$data['comment'] = '';
-	api_plugin_db_table_create ('gridalarms', 'gridalarms_template_metric_expression', $data);
+	api_plugin_db_table_create('gridalarms', 'gridalarms_template_metric_expression', $data);
 
 	//This need to goto new gridalarms tables
 	api_plugin_db_add_column('gridalarms', 'thold_data', array(

--- a/cacti/plugins/gridalarms/includes/notify.php
+++ b/cacti/plugins/gridalarms/includes/notify.php
@@ -2,7 +2,7 @@
 // $Id$
 /*
  +-------------------------------------------------------------------------+
- | Copyright IBM Corp. 2006, 2024                                          |
+ | Copyright IBM Corp. 2006, 2025                                          |
  |                                                                         |
  | Licensed under the Apache License, Version 2.0 (the "License");         |
  | you may not use this file except in compliance with the License.        |
@@ -27,10 +27,6 @@ function gridalarms_notify_list_tabs($tabs) {
 	return $tabs;
 }
 
-/* ------------------------
-    The 'actions' function
-   ------------------------ */
-
 function gridalarms_notify_list_save($save) {
 	global $actions, $assoc_actions;
 
@@ -53,7 +49,7 @@ function gridalarms_notify_list_save($save) {
 							WHERE id = ?',
 							array(get_request_var('id'), $selected_items[$i]));
 					}
-				}elseif (get_request_var('drp_action') == '2') { /* disassociate */
+				} elseif (get_request_var('drp_action') == '2') { /* disassociate */
 					for ($i=0;($i<count($selected_items));$i++) {
 						/* ================= input validation ================= */
 						input_validate_input_number($selected_items[$i]);
@@ -72,7 +68,7 @@ function gridalarms_notify_list_save($save) {
 			header('Location: notify_lists.php?action=edit&header=false&tab=alerts&id=' . get_request_var('id'));
 
 			exit;
-		}elseif (isset_request_var('save_atemplates')) {
+		} elseif (isset_request_var('save_atemplates')) {
 			$selected_items = sanitize_unserialize_selected_items(get_request_var('selected_items'));
 			input_validate_input_number(get_request_var('notification_action'));
 
@@ -89,7 +85,7 @@ function gridalarms_notify_list_save($save) {
 							WHERE id = ?',
 							array(get_request_var('id'), $selected_items[$i]));
 					}
-				}elseif (get_request_var('drp_action') == '2') { /* disassociate */
+				} elseif (get_request_var('drp_action') == '2') { /* disassociate */
 					for ($i=0;($i<count($selected_items));$i++) {
 						/* ================= input validation ================= */
 						input_validate_input_number($selected_items[$i]);
@@ -159,7 +155,7 @@ function gridalarms_notify_list_form_confirm($save) {
 				</tr>\n";
 
 				$save_html = "<input type='button' value='" . __esc('Cancel', 'gridalarms') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' value='" . __esc('Continue', 'gridalarms') . "' title='" . __esc('Associate Notification Lists', 'gridalarms') . "'>";
-			}elseif (get_request_var('drp_action') == '2') { /* disassociate */
+			} elseif (get_request_var('drp_action') == '2') { /* disassociate */
 				print "<tr>
 					<td class='textArea'>
 						<p>" . __('Click \'Continue\' to Disassociate the Alerts below from the Notification List \'<b>%s</b>\'.', html_escape($list_name), 'gridalarms') . "</p>
@@ -187,7 +183,7 @@ function gridalarms_notify_list_form_confirm($save) {
 		</tr>";
 
 		html_end_box();
-	}elseif (isset_request_var('save_atemplates')) {
+	} elseif (isset_request_var('save_atemplates')) {
 		/* loop through each of the notification lists selected on the previous page and get more info about them */
 		foreach ($_POST as $var => $val) {
 			if (preg_match("/^chk_([0-9]+)$/", $var, $matches)) {
@@ -217,7 +213,7 @@ function gridalarms_notify_list_form_confirm($save) {
 				</tr>\n";
 
 				$save_html = "<input type='button' value='" . __esc('Cancel', 'gridalarms') . "' onClick='cactiReturnTo()'>&nbsp;<input type='submit' value='" . __esc('Continue', 'gridalarms') . "' title='" . __esc('Associate Notification Lists', 'gridalarms') . "'>";
-			}elseif (get_request_var('drp_action') == '2') { /* disassociate */
+			} elseif (get_request_var('drp_action') == '2') { /* disassociate */
 				print "<tr>
 					<td class='textArea'>
 						<p>" . __('Click \'Continue\' to Disassociate the Alert Templates below from the Notification List \'<b>%s</b>\'.', html_escape($list_name), 'gridalarms') . "</p>
@@ -264,7 +260,7 @@ function gridalarms_notify_list_display($save) {
 
 	if ($current_tab == 'alerts') {
 		alerts($header_label);
-	}elseif ($current_tab == 'atemplates') {
+	} elseif ($current_tab == 'atemplates') {
 		atemplates($header_label);
 	}
 	return $save;
@@ -372,7 +368,7 @@ function alerts($header_label) {
 							<option value='-1'><?php print __('Any', 'gridalarms');?></option>
 							<?php
 							foreach ($alarm_templates as $row) {
-								echo "<option value='" . $row['id'] . "'" . (isset_request_var('template') && $row['id'] == get_request_var('template') ? ' selected' : '') . '>' . html_escape($row['name']) . '</option>';
+								print "<option value='" . $row['id'] . "'" . (isset_request_var('template') && $row['id'] == get_request_var('template') ? ' selected' : '') . '>' . html_escape($row['name']) . '</option>';
 							}
 							?>
 						</select>
@@ -480,7 +476,7 @@ function alerts($header_label) {
 			if (!empty($row['notify_alert'])) {
 				if (get_request_var('id') == $row['notify_alert']) {
 					$alert_stat .= (strlen($alert_stat) ? ', ':'') . "<span class='deviceUp'>" . __('Current List', 'gridalarms') . "</span>";
-				}else{
+				} else {
 					$alert_info = db_fetch_cell_prepared('SELECT name
 						FROM plugin_notification_lists
 						WHERE id = ?',
@@ -500,7 +496,7 @@ function alerts($header_label) {
 
 			if ($row['name'] != '') {
 				$name = $row['name'];
-			}else{
+			} else {
 				$name = $row['name'] . ' [' . $row['data_source_name'] . ']';
 			}
 
@@ -679,7 +675,7 @@ function atemplates($header_label) {
 			if (!empty($row['notify_alert'])) {
 				if (get_request_var('id') == $row['notify_alert']) {
 					$alert_stat .= (strlen($alert_stat) ? ', ':'') . "<span class='deviceUp'>" . __('Current List', 'gridalarms') . '</span>';
-				}else{
+				} else {
 					$alert_info = db_fetch_cell_prepared('SELECT name
 						FROM plugin_notification_lists
 						WHERE id = ?',

--- a/cacti/plugins/gridalarms/includes/settings.php
+++ b/cacti/plugins/gridalarms/includes/settings.php
@@ -2,7 +2,7 @@
 // $Id$
 /*
  +-------------------------------------------------------------------------+
- | Copyright IBM Corp. 2006, 2024                                          |
+ | Copyright IBM Corp. 2006, 2025                                          |
  |                                                                         |
  | Licensed under the Apache License, Version 2.0 (the "License");         |
  | you may not use this file except in compliance with the License.        |
@@ -30,6 +30,24 @@ function gridalarms_config_settings() {
 		'nl_header' => array(
 			'friendly_name' => __('Alert Presets', 'gridalarms'),
 			'method' => 'spacer',
+		),
+		'gridalarm_parallel' => array(
+			'friendly_name' => __('Concurrent Alert Processes', 'gridalarms'),
+			'description' => __('The maximum number of Alert check processes that can be launched in parallel.  The default is 5.', 'gridalarms'),
+			'method' => 'drop_array',
+			'default' => 5,
+			'array' => array(
+				1  => __('%d Processes', 1, 'gridalarms'),
+				2  => __('%d Processes', 2, 'gridalarms'),
+				3  => __('%d Processes', 3, 'gridalarms'),
+				4  => __('%d Processes', 4, 'gridalarms'),
+				5  => __('%d Processes', 5, 'gridalarms'),
+				6  => __('%d Processes', 6, 'gridalarms'),
+				7  => __('%d Processes', 7, 'gridalarms'),
+				8  => __('%d Processes', 8, 'gridalarms'),
+				9  => __('%d Processes', 9, 'gridalarms'),
+				10 => __('%d Processes', 10, 'gridalarms')
+			)
 		),
     	'gridalarm_severity' => array(
 			'friendly_name' => __('Default Alert Severity', 'gridalarms'),

--- a/cacti/plugins/gridalarms/includes/thold.php
+++ b/cacti/plugins/gridalarms/includes/thold.php
@@ -2,7 +2,7 @@
 // $Id$
 /*
  +-------------------------------------------------------------------------+
- | Copyright IBM Corp. 2006, 2024                                          |
+ | Copyright IBM Corp. 2006, 2025                                          |
  |                                                                         |
  | Licensed under the Apache License, Version 2.0 (the "License");         |
  | you may not use this file except in compliance with the License.        |
@@ -25,16 +25,16 @@ function gridalarms_th_edit_save_thold($save) {
 
 		// Host actions
 		$save['host_action_high'] = get_request_var('host_action_high');
-		if($save['host_action_high'] == 1) {//open
+		if ($save['host_action_high'] == 1) {//open
 			$save['host_action_high_lockid'] = get_request_var('host_action_high_open_lockid');
-		} else if($save['host_action_high'] == 2) {//close
+		} else if ($save['host_action_high'] == 2) {//close
 			form_input_validate(trim(get_nfilter_request_var('host_action_high_close_lockid')),   'host_action_high_close_lockid', '^[A-Za-z0-9]+$', true, '148');
 			$save['host_action_high_lockid'] = get_request_var('host_action_high_close_lockid');
 		}
 		$save['host_action_low']  = get_request_var('host_action_low');
-		if($save['host_action_low'] == 1) {//open
+		if ($save['host_action_low'] == 1) {//open
 			$save['host_action_low_lockid'] = get_request_var('host_action_low_open_lockid');
-		} else if($save['host_action_low'] == 2) {//close
+		} else if ($save['host_action_low'] == 2) {//close
 			form_input_validate(trim(get_nfilter_request_var('host_action_low_close_lockid')),   'host_action_low_close_lockid', '^[A-Za-z0-9]+$', true, '148');
 			$save['host_action_low_lockid'] = get_request_var('host_action_low_close_lockid');
 		}
@@ -298,121 +298,123 @@ function gridalarms_th_edit_form_array($form_array) {
 function gridalarms_th_edit_javascript($thold_data) {
 	global $thold_oob_templates;
 ?>
-function switchLSFEventType() {
-			var action_level = $('#gridadmin_action_level').val();
-			$('#row_event_trigger_gridadmin_host').hide();
-			$('#row_host_action_high').hide();
-			$('#row_host_action_high_open_lockid').hide();
-			$('#row_host_action_high_close_lockid').hide();
-			$('#row_host_action_low').hide();
-			$('#row_host_action_low_open_lockid').hide();
-			$('#row_host_action_low_close_lockid').hide();
-			$('#row_event_trigger_gridadmin_job').hide();
-			$('#row_job_action_high').hide();
-			$('#row_job_target_high').hide();
-			$('#row_job_signal_high').hide();
-			$('#row_job_action_low').hide();
-			$('#row_job_target_low').hide();
-			$('#row_job_signal_low').hide();
+	function switchLSFEventType() {
+		var action_level = $('#gridadmin_action_level').val();
 
-			switch(action_level) {
-				case 'job':
-					$('#row_job_action_high').show();
-					$('#row_job_action_low').show();
+		$('#row_event_trigger_gridadmin_host').hide();
+		$('#row_host_action_high').hide();
+		$('#row_host_action_high_open_lockid').hide();
+		$('#row_host_action_high_close_lockid').hide();
+		$('#row_host_action_low').hide();
+		$('#row_host_action_low_open_lockid').hide();
+		$('#row_host_action_low_close_lockid').hide();
+		$('#row_event_trigger_gridadmin_job').hide();
+		$('#row_job_action_high').hide();
+		$('#row_job_target_high').hide();
+		$('#row_job_signal_high').hide();
+		$('#row_job_action_low').hide();
+		$('#row_job_target_low').hide();
+		$('#row_job_signal_low').hide();
 
-					if ($('#job_action_high').val() == '1') { // Bswitch
-						$('#row_job_target_high').show();
-					} else if ($('#job_action_high').val() == '4') {
-						$('#row_job_signal_high').show();
-					}
+		switch(action_level) {
+			case 'job':
+				$('#row_job_action_high').show();
+				$('#row_job_action_low').show();
 
-					if ($('#job_action_low').val() == '1') { // Bswitch
-						$('#row_job_target_low').show();
-					} else if ($('#job_action_low').val() == '4') {
-						$('#row_job_signal_low').show();
-					}
+				if ($('#job_action_high').val() == '1') { // Bswitch
+					$('#row_job_target_high').show();
+				} else if ($('#job_action_high').val() == '4') {
+					$('#row_job_signal_high').show();
+				}
 
-					break;
-				case 'host':
-					$('#row_event_trigger_gridadmin_host').show();
-					$('#row_host_action_high').show();
-					var host_action_high = $('#host_action_high').val();
-					if(host_action_high ==1 ){
-						$('#row_host_action_high_open_lockid').show();
-					} else if (host_action_high ==2 ) {
-						$('#row_host_action_high_close_lockid').show();
-					}
-					$('#row_host_action_low').show();
-					var host_action_low = $('#host_action_low').val();
-					if(host_action_low ==1 ){
-						$('#row_host_action_low_open_lockid').show();
-					} else if (host_action_low ==2 ) {
-						$('#row_host_action_low_close_lockid').show();
-					}
-					break;
-			}
-		};
+				if ($('#job_action_low').val() == '1') { // Bswitch
+					$('#row_job_target_low').show();
+				} else if ($('#job_action_low').val() == '4') {
+					$('#row_job_signal_low').show();
+				}
 
-		$('#gridadmin_action_level, #job_action_high, #job_action_low, #host_action_high, #host_action_low').off('change').on('change', function() {
-			switchLSFEventType();
-		});
+				break;
+			case 'host':
+				$('#row_event_trigger_gridadmin_host').show();
+				$('#row_host_action_high').show();
 
-		$('#template_enabled').on('change', function() {
-			var status = $('#template_enabled').is(':checked');
+				var host_action_high = $('#host_action_high').val();
+				if (host_action_high == 1) {
+					$('#row_host_action_high_open_lockid').show();
+				} else if (host_action_high ==2 ) {
+					$('#row_host_action_high_close_lockid').show();
+				}
+				$('#row_host_action_low').show();
+				var host_action_low = $('#host_action_low').val();
+				if (host_action_low == 1) {
+					$('#row_host_action_low_open_lockid').show();
+				} else if (host_action_low ==2 ) {
+					$('#row_host_action_low_close_lockid').show();
+				}
+				break;
+		}
+	};
+
+	$('#gridadmin_action_level, #job_action_high, #job_action_low, #host_action_high, #host_action_low').off('change').on('change', function() {
+		switchLSFEventType();
+	});
+
+	$('#template_enabled').on('change', function() {
+		var status = $('#template_enabled').is(':checked');
 	<?php
 	if (read_config_option('gridalarm_thold_detail') != 'on'
 		&& isset($thold_data['data_template_hash'])
-		&& !array_key_exists($thold_data['data_template_hash'], $thold_oob_templates)){
+		&& !array_key_exists($thold_data['data_template_hash'], $thold_oob_templates)) {
 		//Only enable LSF event triggering type drop-down list with out-of-box templates
 	?>
-		$('#gridadmin_action_level').attr('disabled', true);
-		if($('#gridadmin_action_level').selectmenu('instance')) {
-			$('#gridadmin_action_level').selectmenu('disable');
-		}
+	$('#gridadmin_action_level').attr('disabled', true);
+	if ($('#gridadmin_action_level').selectmenu('instance')) {
+		$('#gridadmin_action_level').selectmenu('disable');
+	}
 	<?php
 	} else {?>
-		$('#gridadmin_action_level').prop('disabled', status);
+	$('#gridadmin_action_level').prop('disabled', status);
 	<?php
 	}?>
-		$('#row_host_action_high').prop('disabled', status);
-			$('#row_host_action_high_open_lockid').prop('disabled', status);
-			$('#row_host_action_high_close_lockid').prop('disabled', status);
-			$('#row_host_action_low').prop('disabled', status);
-			$('#row_host_action_low_open_lockid').prop('disabled', status);
-			$('#row_host_action_low_close_lockid').prop('disabled', status);
-			$('#job_action_high').prop('disabled', status);
-			$('#job_target_high').prop('disabled', status);
-			$('#job_signal_high').prop('disabled', status);
-			$('#job_action_low').prop('disabled', status);
-			$('#job_target_low').prop('disabled', status);
-			$('#job_signal_low').prop('disabled', status);
+	$('#row_host_action_high').prop('disabled', status);
+		$('#row_host_action_high_open_lockid').prop('disabled', status);
+		$('#row_host_action_high_close_lockid').prop('disabled', status);
+		$('#row_host_action_low').prop('disabled', status);
+		$('#row_host_action_low_open_lockid').prop('disabled', status);
+		$('#row_host_action_low_close_lockid').prop('disabled', status);
+		$('#job_action_high').prop('disabled', status);
+		$('#job_target_high').prop('disabled', status);
+		$('#job_signal_high').prop('disabled', status);
+		$('#job_action_low').prop('disabled', status);
+		$('#job_target_low').prop('disabled', status);
+		$('#job_signal_low').prop('disabled', status);
 
-			if (status) {
-				$('input:not(:button):not(:submit), textarea, select').each(function() {
-					$(this).addClass('ui-state-disabled');
-					if ($(this).selectmenu('instance')) {
-						$(this).selectmenu('disable');
-					}
-				});
-			} else {
-				$('input:not(:button):not(:submit), textarea, select').each(function() {
-					$(this).removeClass('ui-state-disabled');
-					if ($(this).selectmenu('instance')) {
+		if (status) {
+			$('input:not(:button):not(:submit), textarea, select').each(function() {
+				$(this).addClass('ui-state-disabled');
+				if ($(this).selectmenu('instance')) {
+					$(this).selectmenu('disable');
+				}
+			});
+		} else {
+			$('input:not(:button):not(:submit), textarea, select').each(function() {
+				$(this).removeClass('ui-state-disabled');
+				if ($(this).selectmenu('instance')) {
 						$(this).selectmenu('enable');
-					}
-				});
-			}
-		});
+				}
+			});
+		}
+	});
 
 	$(function() {
 <?php
 	if (read_config_option('gridalarm_thold_detail') != 'on'
 		&& isset($thold_data['data_template_hash'])
-		&& !array_key_exists($thold_data['data_template_hash'], $thold_oob_templates)){
+		&& !array_key_exists($thold_data['data_template_hash'], $thold_oob_templates)) {
 	//Only enable LSF event triggering type drop-down list with out-of-box templates
 	?>
 		$('#gridadmin_action_level').attr('disabled', true);
-		if($('#gridadmin_action_level').selectmenu('instance')) {
+		if ($('#gridadmin_action_level').selectmenu('instance')) {
 			$('#gridadmin_action_level').selectmenu('disable');
 		}
 <?php
@@ -533,7 +535,7 @@ function gridalarms_thold_gridcontrol_exec($save) {
 
 	foreach($breach_info as $breachinfo) {  //populating data to be parse to the function sorting_json_format
 		$keysvalue = array_keys($breachinfo);
-		foreach($keysvalue as $keys){
+		foreach($keysvalue as $keys) {
 			if ($keys == 'HostName') {
 				$targetvalue[] = $breachinfo['HostName'] . ':' . $clusterid;
 			} elseif ($keys == 'JobID') {
@@ -628,7 +630,7 @@ function gridalarms_thold_gridcontrol_exec($save) {
 	}
 }
 
-function gridalarms_fetch_breached_info($local_data_id){
+function gridalarms_fetch_breached_info($local_data_id) {
 	global $called_by_script_server;
 
 	$type_id = db_fetch_cell_prepared('SELECT di.type_id
@@ -653,7 +655,7 @@ function gridalarms_fetch_breached_info($local_data_id){
 			include_once($length[0]);
 
 			$input_parameter = cacti_sizeof($length) - 2 ;
-			for($i=1; $i<=cacti_sizeof($length)-1; $i++){
+			for($i=1; $i<=cacti_sizeof($length)-1; $i++) {
 				$length[$i] = trim($length[$i], "' \t\n\r\0\x0B");
 			}
 
@@ -726,7 +728,7 @@ function gridalarms_thold_graph_actions_url($data) {
 		if ($thold_data['gridadmin_action_level'] == ''
 			|| $thold_data['gridadmin_action_level'] == 'none'
 			|| (read_config_option('gridalarm_thold_detail') != 'on'
-				&& !array_key_exists($thold_data['data_template_hash'], $thold_oob_templates))){
+				&& !array_key_exists($thold_data['data_template_hash'], $thold_oob_templates))) {
 			//Show breach item icon with out-of-box templates or global enabled
 			return $data;
 		}

--- a/cacti/plugins/gridalarms/lib/gridalarms_functions.php
+++ b/cacti/plugins/gridalarms/lib/gridalarms_functions.php
@@ -2,7 +2,7 @@
 // $Id$
 /*
  +-------------------------------------------------------------------------+
- | Copyright IBM Corp. 2006, 2024                                          |
+ | Copyright IBM Corp. 2006, 2025                                          |
  |                                                                         |
  | Licensed under the Apache License, Version 2.0 (the "License");         |
  | you may not use this file except in compliance with the License.        |
@@ -19,16 +19,19 @@
 */
 
 global $config;
+
 include_once($config['library_path'] . '/rtm_functions.php');
 include_once(dirname(__FILE__) . '/../setup.php');
 
 /**
  * takes a string of text, and performs variable replacement on it
- * @param $script 		- the string to evaluate
- * @param $alarm	 	- the array containing Alert or template information
- * @returns 			- the modified script
+ *
+ * @param string  $script - the string to evaluate
+ * @param array   $alarm - the array containing Alert or template information
+ *
+ * @return string the modified script
  */
-function do_script_variable_replacement($script, $alarm) {
+function do_script_variable_replacement(string $script, array $alarm) : string {
 	$result_script = $script;
 
 	if ($alarm['clusterid'] > 0) {
@@ -50,10 +53,10 @@ function do_script_variable_replacement($script, $alarm) {
 
 /**
  * purges old entries from the alert log
- * @param 					- none
- * @returns 				- null
+ *
+ * @return null
  */
-function gridalarms_alarm_log_cleanup() {
+function gridalarms_alarm_log_cleanup() : void {
 	/* keep days of logs based on the setting of gridalarms_alarm_log_cleanup in console->setting->alerting/thold*/
 
 	$alarm_log_retention = read_config_option('gridalarms_alarm_log_cleanup');
@@ -71,10 +74,12 @@ function gridalarms_alarm_log_cleanup() {
 
 /**
  * returns columns available for an alert expression
- * @param $expression_id	- the id of the expression to query
- * @returns					- an array of column names
+ *
+ * @param int - $expression_id - the id of the expression to query
+ *
+ * @return array - an array of column names
  */
-function gridalarms_get_sql_columns($expression_id) {
+function gridalarms_get_sql_columns(int $expression_id) : array {
 	$sql = db_fetch_cell_prepared('SELECT sql_query
 		FROM gridalarms_expression
 		WHERE id = ?',
@@ -93,10 +98,12 @@ function gridalarms_get_sql_columns($expression_id) {
 
 /**
  * returns columns available for an template expression
- * @param $expression_id	- the id of the expression to query
- * @returns					- an array of column names
+ *
+ * @param int $expression_id - the id of the expression to query
+ *
+ * @return array - an array of column names
  */
-function gridalarms_get_template_sql_columns($expression_id) {
+function gridalarms_get_template_sql_columns(int $expression_id) : array {
 	$sql = db_fetch_cell_prepared('SELECT sql_query
 		FROM gridalarms_template_expression
 		WHERE id = ?',
@@ -115,6 +122,7 @@ function gridalarms_get_template_sql_columns($expression_id) {
 
 /**
  * logs an entry to the local systems syslog facility
+ *
  * @param $syslog_level		- the severity/priority of the syslog message
  * @param $syslog_facility	- the facility to log the event to
  * @param $name				- the name of the event
@@ -123,9 +131,10 @@ function gridalarms_get_template_sql_columns($expression_id) {
  * @param $currentval		- the currently measured value
  * @param $trigger			- unused, the threshold trigger count
  * @param $triggerct		- unused, the current trigger count
- * @returns					- none
+ *
+ * @return null
  */
-function rtm_logger($syslog_level, $syslog_facility, $name, $breach_up, $threshld, $currentval, $trigger, $triggerct) {
+function rtm_logger(int $syslog_level, int $syslog_facility, string $name, int $breach_up, mixed $threshld, mixed $currentval, int $trigger, int $triggerct) : void {
 	if (function_exists('define_syslog_variables')) define_syslog_variables();
 
 	if (!isset($syslog_level)) {
@@ -151,15 +160,21 @@ function rtm_logger($syslog_level, $syslog_facility, $name, $breach_up, $threshl
 
 /**
  * sends an alert event to the Email recipients
- * @param $to				- the list of addresses the Email will go to
- * @param $from				- the senders Email address
- * @param $subject			- the Email subject
- * @param $message			- the Email body
- * @param $textonly			- a boolean defining if simple text should be forced
- * @returns					- null upon success, or error on failure
+ *
+ * @param $to          - the list of addresses the Email will go to
+ * @param $from        - the senders Email address
+ * @param $subject     - the Email subject
+ * @param $message     - the Email body
+ * @param $format_file - a boolean defining if simple text should be forced
+ * @param $textonly    - display mail as text (not used)
+ *
+ * @return null|string null upon success, or error on failure
  */
-function alarm_mail($to, $from, $subject, $message, $textonly = false) {
+function alarm_mail(mixed $to, mixed $from, string $subject, string $message, string $format_file = '', bool $textonly = false) : ?string {
 	global $config;
+
+	include_once('./lib/reports.php');
+
 	$subject = trim($subject);
 	$message = str_replace('<SUBJECT>', $subject, $message);
 
@@ -174,15 +189,35 @@ function alarm_mail($to, $from, $subject, $message, $textonly = false) {
 	}
 
 	$html = $message;
-	/* apply for format css */
-	if (file_exists($config['base_path'] . '/plugins/gridalarms/formats/alert.format')) {
+
+	if ($format_file != '') {
+		$format_data = '';
+		$report_tag  = false;
+		$format_ok   = false;
+		$theme       = 'classic';
+
+		$format_ok = reports_load_format_file($format_file, $format_data, $report_tag, $theme);
+
+		if ($format_ok) {
+			if ($report_tag) {
+				$html = str_replace('<REPORT>', $message, $format_data);
+			} else {
+				$html = $format_data . PHP_EOL . $message;
+			}
+		} else {
+			$html = $outstr;
+		}
+	} elseif (file_exists($config['base_path'] . '/plugins/gridalarms/formats/alert.format')) {
 		$format = file_get_contents($config['base_path'] . '/plugins/gridalarms/formats/alert.format');
+
 		$html = str_replace('<REPORT>', $message, $format);
 		$html = str_ireplace('bgcolor="#00438C"', '', $html);
 		$html = str_ireplace('bgcolor="#E1E1E1"', '', $html);
 		$html = str_ireplace("bgcolor='#6d88ad'", '', $html);
 	}
+
 	$text = array('text' => '', 'html' => '');
+
 	if ($textonly) {
 		$text['html'] = $message . '<br>';
 
@@ -202,7 +237,7 @@ function alarm_mail($to, $from, $subject, $message, $textonly = false) {
 	$headers['User-Agent'] = 'gridalarms-v' . $version;
 
 	$error = mailer(
-		array(array($from, $from_name)),
+		array($from, $from_name),
 		$to,
 		'',
 		'',
@@ -226,11 +261,14 @@ function alarm_mail($to, $from, $subject, $message, $textonly = false) {
 
 /**
  * returns columns available for an template expression
+ *
  * @param $expression_id	- the id of the expression to query
- * @returns					- an array of column names
+ *
+ * @return - an array of column names
  */
-function plugin_alarm_duration_convert($data, $type) {
+function plugin_alarm_duration_convert(string $data, string $type) : string{
 	global $repeatarray, $alertarray, $timearray;
+
 	/* handle a null data value */
 	if ($data == '') {
 		return '';
@@ -253,14 +291,21 @@ function plugin_alarm_duration_convert($data, $type) {
 
 /**
  * return a comma delimited list of admin Email addresses for the cluster
+ *
  * @param $clusterid		- the id of the cluster in question
- * @returns					- a string of the cluster admins emails
+ *
+ * @return - a string of the cluster admins emails
  */
-function get_cluster_admins($clusterid) {
+function get_cluster_admins(int $clusterid) : string {
 	if ($clusterid > 0) {
-		$rows  = db_fetch_assoc_prepared('SELECT email_admin FROM grid_clusters WHERE clusterid = ?', array($clusterid));
+		$rows = db_fetch_assoc_prepared('SELECT email_admin
+			FROM grid_clusters
+			WHERE clusterid = ?',
+			array($clusterid));
 	} else {
-		$rows  = db_fetch_assoc('SELECT email_admin FROM grid_clusters');
+		$rows = db_fetch_assoc('SELECT DISTINCT email_admin
+			FROM grid_clusters
+			ORDER BY email_admin');
 	}
 
 	$all_cluster_emails = array();
@@ -270,7 +315,7 @@ function get_cluster_admins($clusterid) {
 		foreach ($rows as $row) {
 			$one_cluster_emails = explode(',', $row['email_admin']);
 			foreach ($one_cluster_emails as $e) {
-				if (strlen(trim($e)) >0) {
+				if (strlen(trim($e)) > 0) {
 					$all_cluster_emails[$e] = $e;
 				}
 			}
@@ -287,10 +332,12 @@ function get_cluster_admins($clusterid) {
 
 /**
  * return a comma delimited list of Email addresses for an alarm
+ *
  * @param $alarm			- the alarm to be used to construct the Email list
- * @returns					- a string of the cluster admins emails
+ *
+ * @return - a string of the cluster admins emails
  */
-function gridalarms_build_email_list($alarm) {
+function gridalarms_build_email_list(array $alarm) : string {
 	$alarm_emails = array();
 
 	if (read_config_option('gridalarm_disable_legacy') != 'on') {
@@ -309,8 +356,9 @@ function gridalarms_build_email_list($alarm) {
 			}
 		}
 
-		if (isset($alarm['notify_extra']) && strlen(trim($alarm['notify_extra']))) {
+		if (isset($alarm['notify_extra']) && $alarm['notify_extra'] != '') {
 			$emails = explode(',', $alarm['notify_extra']);
+
 			foreach ($emails as $e) {
 				$e = trim($e);
 				$alarm_emails[$e] = $e;
@@ -320,9 +368,11 @@ function gridalarms_build_email_list($alarm) {
 
 	if ($alarm['notify_cluster_admin'] == 1) {
 		$emails = explode(',', get_cluster_admins($alarm['clusterid']));
+
 		if (cacti_sizeof($emails) > 0) {
 			foreach ($emails as $e) {
-			$e = trim($e);
+				$e = trim($e);
+
 				$alarm_emails[$e] = $e;
 			}
 		}
@@ -351,10 +401,12 @@ function gridalarms_build_email_list($alarm) {
 
 /**
  * return a properly formated breach details for an alarm script
- * @param $alarm			- the alarm to be used to construct the Email list
- * @returns					- formatted list of breached items
+ *
+ * @param $alarm        the alarm to be used to construct the Email list
+ *
+ * @return string|array formatted list of breached items
  */
-function get_alarm_breach_details_for_script($alarm) {
+function get_alarm_breach_details_for_script(array $alarm) : string|array {
 	$expression = get_expression_by_id($alarm['expression_id']);
 
 	if (cacti_sizeof($expression)) {
@@ -366,10 +418,12 @@ function get_alarm_breach_details_for_script($alarm) {
 
 /**
  * return a properly formated header for breach details
- * @param $alarm			- the alarm to be used to construct the Email list
- * @returns					- formatted list breached item header
+ *
+ * @param $alarm        the alarm to be used to construct the Email list
+ *
+ * @return string|array formatted list breached item header
  */
-function get_alarm_breach_details_headers_for_script($alarm) {
+function get_alarm_breach_details_headers_for_script(array $alarm) : string|array {
 	/* expression type */
 	$expression = get_expression_by_alarm_id($alarm['id']);
 
@@ -395,10 +449,12 @@ function get_alarm_breach_details_headers_for_script($alarm) {
 
 /**
  * return a properly formated db columns name for breach details
- * @param $alarm			- the alarm to be used to construct the Email list
- * @returns					- formatted list breached item db columns name
+ *
+ * @param $alarm      the alarm to be used to construct the Email list
+ *
+ * @return string|array formatted list breached item db columns name
  */
-function get_alarm_breach_details_columns_for_script($alarm) {
+function get_alarm_breach_details_columns_for_script(array $alarm) : string|array {
 	/* expression type */
 	$expression = get_expression_by_alarm_id($alarm['id']);
 
@@ -424,12 +480,14 @@ function get_alarm_breach_details_columns_for_script($alarm) {
 
 /**
  * do tag subsitution on special variables for gridalarms scripts
- * @param $script			- the script to update
- * @param $currentval		- the current value of the alert
- * @param $alarm			- the alarm to be used to construct the Email list
- * @returns					- updated script
+ *
+ * @param string  $script the script to update
+ * @param mixed   $currentval the current value of the alert
+ * @param array   $alarm the alarm to be used to construct the Email list
+ *
+ * @return string updated script
  */
-function gridalarms_script_replace($script, $currentval, $alarm) {
+function gridalarms_script_replace(string $script, mixed $currentval, array $alarm) : string {
 	global $alarm_types;
 
 	/* the current values */
@@ -464,13 +522,15 @@ function gridalarms_script_replace($script, $currentval, $alarm) {
 
 /**
  * do tag subsitution on special variables for gridalarms messages
- * @param $alarm_text		- the alarm text to update
- * @param $currentval		- the current value of the alert
- * @param $alarm			- the alarm to be used to construct the Email list
- * @param $admin			- the are we performing replacement for the admin
- * @returns					- updated alert text
+ *
+ * @param string  $alarm_text the alarm text to update
+ * @param mixed   $currentval the current value of the alert
+ * @param array   $alarm the alarm to be used to construct the Email list
+ * @param bool    $admin the are we performing replacement for the admin
+ *
+ * @return string updated alert text
  */
-function gridalarms_text_replace($alarm_text, $currentval, $alarm, $bitems = '', $admin = false) {
+function gridalarms_text_replace(string $alarm_text, mixed $currentval, array $alarm, string $bitems = '', bool $admin = false) : string {
 	global $config, $alarm_types;
 
 	/* the current values */
@@ -518,7 +578,7 @@ function gridalarms_text_replace($alarm_text, $currentval, $alarm, $bitems = '',
 	return $alarm_text;
 }
 
-function gridalarms_replace_custom_input($expression_id, $text) {
+function gridalarms_replace_custom_input(int $expression_id, string $text) : string {
 	$items = db_fetch_assoc_prepared('SELECT name, value
 		FROM gridalarms_expression_input
 		WHERE expression_id = ?',
@@ -533,7 +593,7 @@ function gridalarms_replace_custom_input($expression_id, $text) {
 	return $text;
 }
 
-function gridalarms_template_replace_custom_input($expression_id, $text) {
+function gridalarms_template_replace_custom_input(int $expression_id, string $text) : string {
 	$items = db_fetch_assoc_prepared('SELECT name, value
 		FROM gridalarms_template_expression_input
 		WHERE expression_id = ?',
@@ -550,10 +610,12 @@ function gridalarms_template_replace_custom_input($expression_id, $text) {
 
 /**
  * run the properly formatted script and discard results
- * @param $script			- the script to execute
- * @returns					- null
+ *
+ * @param string $script the script to execute
+ *
+ * @return null
  */
-function gridalarms_exec_scripts($script) {
+function gridalarms_exec_scripts(string $script) : void {
 	global $config;
 
 	$script    = str_replace('<CACTI_ROOT>', $config['base_path'], $script);
@@ -565,19 +627,21 @@ function gridalarms_exec_scripts($script) {
 		exec($command, $output, $exit_code);
 
 		if ($exit_code != 0) {
-			cacti_log("WARNING: Unable to execute Command: '" . $command ."', Output: '" . implode(', ', $output), false, 'GRIDALERTS');
+			cacti_log("WARNING: Unable to execute Command: '" . $command ."', Output: '" . implode(', ', $output) . "'", false, 'GRIDALERTS');
 		}
 	}
 }
 
 /**
  * function to check an alarm based upon the alarm entry
- * @param $alarm			- the alarm to be used to construct the Email list
- * @param $force			- ignore frequency settings and run forcibly
- * @returns					- null
+ *
+ * @param array  $alarm the alarm to be used to construct the Email list
+ * @param bool   $force ignore frequency settings and run forcibly
+ *
+ * @return null
  */
-function gridalarms_check_alarm($alarm, $force = false) {
-	global $config, $debug, $alarm_types, $gridalarms_types;
+function gridalarms_check_alarm(array $alarm, bool $force = false) : void {
+	global $config, $debug, $alarm_types, $gridalarms_types, $plugins;
 
 	include_once($config['base_path'] . '/lib/variables.php');
 
@@ -605,10 +669,38 @@ function gridalarms_check_alarm($alarm, $force = false) {
 	/* Get all the info about the item from the database */
 	$expression = get_expression_by_id($alarm['expression_id']);
 
+	/* check for general exemptions */
+	$alert_exempt = read_config_option('alert_exempt');
+
+	$weekday = date('l');
+	if (($weekday == 'Saturday' || $weekday == 'Sunday') && $alert_exempt == 'on') {
+		gridalarms_debug('Alert checking is disabled by global weekend exemption');
+		return;
+	}
+
 	/* Check for the weekend exemption on the threshold level */
 	if (($weekday == 'Saturday' || $weekday == 'Sunday') && $alarm['exempt'] == 'on') {
 		gridalarms_debug('NOTE   - Weekend Exemption in Affect (Current Alert) - Exiting');
 		return;
+	}
+
+	/**
+	 * Don't alert for this Cluster if it's selected for maintenance
+	 * this is more difficult with alerts that cover multiple clusters
+	 * so only support cluster specific checks for now.
+	 */
+	if ((api_plugin_is_enabled('maint') || in_array('maint', $plugins)) && $alarm['clusterid'] > 0) {
+		include_once($config['base_path'] . '/plugins/maint/functions.php');
+
+		$host_id = db_fetch_cell_prepared('SELECT cacti_host
+			FROM grid_clusters
+			WHERE clusterid = ?',
+			array($alarm['clusterid']));
+
+		if (plugin_maint_check_cacti_host($host_id)) {
+			gridalarms_debug('Alert checking is disabled for Cluster by maintenance schedule');
+			return;
+		}
 	}
 
 	/* measure the current value */
@@ -697,11 +789,11 @@ function gridalarms_check_alarm($alarm, $force = false) {
 	db_execute_prepared('UPDATE gridalarms_alarm
 		SET lastread = ?
 		WHERE id = ?',
-		array($currentval, $alarm['id']));
+		array($currentval, $id));
 
 	/* get the breached items for logging */
 	gridalarms_debug('NOTE:  - Getting Breached Items');
-	$bitems = alarm_breached_items($alarm['id'], true);
+	$bitems = alarm_breached_items($id, true);
 	gridalarms_debug('NOTE:  - Getting Breached Items Completed');
 
 	/* variables for sysloging */
@@ -758,9 +850,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 				}
 
 				if (trim($alarm_emails) != '') {
-					//cacti_log('DEBUG: Email list =' . $alarm_emails);
-
-					alarm_mail($alarm_emails, '', $subject, $msg);
+					alarm_mail($alarm_emails, '', $subject, $msg, $alarm['format_file']);
 				}
 
 				// After the alarm is breached(up or down) , notify admin and notify job users.
@@ -770,7 +860,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 					db_execute_prepared('UPDATE gridalarms_alarm
 						SET acknowledgement="on"
 						WHERE id = ?',
-						array($alarm['id']));
+						array($id));
 				}
 
 				/*When "Run the Event Triggering Command on the Retriggered Alert" checked,  high/low post scripts are alowed to run in re-alert*/
@@ -809,15 +899,15 @@ function gridalarms_check_alarm($alarm, $force = false) {
 			/* don't log notice events for now.  log becomes quite chatty */
 			if ($status != 3) {
 				alarm_log(array(
-					'type' => 0,
-					'time' => time(),
-					'alarm_id' => $alarm['id'],
+					'type'        => 0,
+					'time'        => time(),
+					'alarm_id'    => $id,
 					'alarm_value' => ($breach_up ? $alarm['alarm_hi'] : $alarm['alarm_low']),
-					'current' => $currentval,
-					'status' => $status,
+					'current'     => $currentval,
+					'status'      => $status,
 					'description' => $logmsg,
-					'emails' => $alarm_emails,
-					'details' => $bitems)
+					'emails'      => $alarm_emails,
+					'details'     => $bitems)
 				);
 			}
 
@@ -825,11 +915,11 @@ function gridalarms_check_alarm($alarm, $force = false) {
 				FROM gridalarms_alarm_layout
 				WHERE alarm_id = ?
 				AND column_name IN ("host", "hostname", "exec_host", "from_host")',
-				array($alarm['id']));
+				array($id));
 
 			if ($db_columns) {
 				$alarm_logs = db_fetch_assoc_prepared('SELECT a.clusterid, MIN(c.time) AS time,
-					b.name, b.email_subject,a.alarm_id,
+					b.name, b.email_subject, a.alarm_id,
 					a.host AS  alarmhost
 					FROM gridalarms_alarm_log_items AS a
 					INNER JOIN gridalarms_alarm AS b
@@ -839,12 +929,12 @@ function gridalarms_check_alarm($alarm, $force = false) {
 					WHERE a.alarm_id = ?
 					AND a.host != ""
 					GROUP BY alarm_id, alarmhost, clusterid',
-					array($alarm['id']));
+					array($id));
 
 				if (cacti_sizeof($alarm_logs)) {
 					foreach ($alarm_logs as $log) {
-						$log['email_subject']=$subject;
-						api_plugin_hook_function('gridalarms_update_hostsalarm',$log);
+						$log['email_subject'] = $subject;
+						api_plugin_hook_function('gridalarms_update_hostsalarm', $log);
 					}
 				}
 			}
@@ -869,7 +959,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 						$status = 0;
 
 						if (trim($alarm_emails) != '') {
-							alarm_mail($alarm_emails, '', $subject, $msg);
+							alarm_mail($alarm_emails, '', $subject, $msg, $alarm['format_file']);
 						}
 
 						// After the alarm is breached(up or down) , notify admin and notify job users.
@@ -882,19 +972,19 @@ function gridalarms_check_alarm($alarm, $force = false) {
 						db_execute_prepared('UPDATE gridalarms_alarm
 							SET acknowledgement="on"
 							WHERE id = ?',
-							array($alarm['id']));
+							array($id));
 					}
 
 					alarm_log(array(
-						'type' => 0,
-						'time' => time(),
-						'alarm_id' => $alarm['id'],
+						'type'        => 0,
+						'time'        => time(),
+						'alarm_id'    => $id,
 						'alarm_value' => '',
-						'current' => $currentval,
-						'status' => $status,
+						'current'     => $currentval,
+						'status'      => $status,
 						'description' => $logmsg,
-						'emails' => $alarm_emails,
-						'details' => $bitems)
+						'emails'      => $alarm_emails,
+						'details'     => $bitems)
 					);
 
 					/* execute post restoration script */
@@ -936,7 +1026,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 			WHERE alarm_id = ?
 			AND status NOT IN (0,4,99)
 			AND time > ?',
-			array($alarm['id'], $time));
+			array($id, $time));
 
 		if ($alarm['alarm_alert']) {
 			$failures += $alarm['alarm_fail_count'];
@@ -950,7 +1040,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 				WHERE alarm_id = ?
 				AND (status = 1 OR status = 2)
 				ORDER BY time DESC
-				LIMIT 1', array($alarm['id']));
+				LIMIT 1', array($id));
 
 			$ra     = ($failures > $trigger && $alarm['repeat_alert'] != 0 && $lastemailtime > 1 && ($lastemailtime < $realerttime));
 			$status = 3;
@@ -968,7 +1058,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 					FROM gridalarms_alarm_log
 					WHERE alarm_id = ?
 					ORDER BY time DESC',
-					array($alarm['id']));
+					array($id));
 
 				if (($lastalert['status'] == 1 || $lastalert['status'] == 2) && $time> $lastalert['time']) {
 					$status = 3;
@@ -993,7 +1083,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 				}
 
 				if (trim($alarm_emails) != '') {
-					alarm_mail($alarm_emails, '', $subject, $msg);
+					alarm_mail($alarm_emails, '', $subject, $msg, $alarm['format_file']);
 				}
 
 				// After the alarm is breached(up or down) , notify admin and notify job users.
@@ -1003,7 +1093,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 					db_execute_prepared('UPDATE gridalarms_alarm
 						SET acknowledgement="on"
 						WHERE id = ?',
-						array($alarm['id']));
+						array($id));
 				}
 
 				/* When "Run the Event Triggering Command on the Retriggered Alert" checked,
@@ -1040,22 +1130,22 @@ function gridalarms_check_alarm($alarm, $force = false) {
 			}
 
 			alarm_log(array(
-				'type' => 1,
-				'time' => time(),
-				'alarm_id' => $alarm['id'],
+				'type'        => 1,
+				'time'        => time(),
+				'alarm_id'    => $id,
 				'alarm_value' => ($breach_up ? $alarm['time_hi'] : $alarm['time_low']),
-				'current' => $currentval,
-				'status' => $status,
+				'current'     => $currentval,
+				'status'      => $status,
 				'description' => $logmsg,
-				'emails' => $alarm_emails,
-				'details' => $bitems)
+				'emails'      => $alarm_emails,
+				'details'     => $bitems)
 			);
 
-			$db_columns = db_fetch_cell_prepared('SELECT count(*)
+			$db_columns = db_fetch_cell_prepared('SELECT COUNT(*)
 				FROM gridalarms_alarm_layout
 				WHERE alarm_id = ?
 				AND column_name IN ("host", "hostname", "exec_host", "from_host")',
-				array($alarm['id']));
+				array($id));
 
  			if ($db_columns) {
 				$alarm_logs = db_fetch_assoc_prepared('SELECT a.clusterid, MIN(c.time) AS time,
@@ -1068,12 +1158,13 @@ function gridalarms_check_alarm($alarm, $force = false) {
 					WHERE a.alarm_id = ?
 					AND a.host != ""
 					GROUP BY alarm_id, alarmhost, clusterid',
-					array($alarm['id']));
+					array($id));
 
 				if (cacti_sizeof($alarm_logs)) {
 					foreach ($alarm_logs as $log) {
-						$log['email_subject']=$subject;
-						api_plugin_hook_function('gridalarms_update_hostsalarm',$log);
+						$log['email_subject'] = $subject;
+
+						api_plugin_hook_function('gridalarms_update_hostsalarm', $log);
 					}
 				}
  			}
@@ -1093,9 +1184,11 @@ function gridalarms_check_alarm($alarm, $force = false) {
 
 				if ($alarm['restored_alert'] != 'on') {
 					$status = 0;
+
 					if (trim($alarm_emails) != '') {
-						alarm_mail($alarm_emails, '', $subject, $msg);
+						alarm_mail($alarm_emails, '', $subject, $msg, $alarm['format_file']);
 					}
+
 					// After the alarm is breached(up or down) , notify admin and notify job users.
 					notify_job_users($subject, $alarm, $currentval, $alarm_emails);
 				} else {
@@ -1106,7 +1199,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 					db_execute_prepared('UPDATE gridalarms_alarm
 						SET acknowledgement="on"
 						WHERE id = ?',
-						array($alarm['id']));
+						array($id));
 				}
 
 				/* execute post restoration script */
@@ -1122,15 +1215,15 @@ function gridalarms_check_alarm($alarm, $force = false) {
 
 				/* run event trigger */
 				alarm_log(array(
-					'type' => 1,
-					'time' => time(),
-					'alarm_id' => $alarm['id'],
+					'type'        => 1,
+					'time'        => time(),
+					'alarm_id'    => $id,
 					'alarm_value' => '',
-					'current' => $currentval,
-					'status' => $status,
+					'current'     => $currentval,
+					'status'      => $status,
 					'description' => $logmsg,
-					'emails' => $alarm_emails,
-					'details' => $bitems)
+					'emails'      => $alarm_emails,
+					'details'     => $bitems)
 				);
 
 				db_execute_prepared('UPDATE gridalarms_alarm
@@ -1160,8 +1253,7 @@ function gridalarms_check_alarm($alarm, $force = false) {
 		array($end_time - $start_time,  $start_date, $id));
 }
 
-
-function notify_job_users($subject, $alarm, $currentval, $sent_emails) {
+function notify_job_users(string $subject, array $alarm, mixed $currentval, mixed $sent_emails) : void {
 	if (!($alarm['notify_cluster_admin'] == 1 || $alarm['notify_users'] == 'on')) return;
 
 	$poller_interval = read_config_option('poller_interval') ;
@@ -1170,15 +1262,16 @@ function notify_job_users($subject, $alarm, $currentval, $sent_emails) {
 	}
 
 	$total_gal_id_array = array();
-	$gal_id_array = array();
+	$gal_id_array       = array();
+	$id                 = $alarm['id'];
 
 	$columns = array_rekey(
-		db_fetch_assoc_prepared('SELECT column_name, display_name
+		db_fetch_assoc_prepared('SELECT column_name, display_name, type, units, align, digits, autoscale
 			FROM gridalarms_alarm_layout
 			WHERE alarm_id = ?
 			ORDER BY sequence ASC',
 			array($alarm['id'])),
-		'column_name', 'display_name'
+		'column_name', array('display_name', 'type', 'units', 'align', 'digits', 'autoscale')
 	);
 
 	// when notify_cluster_admin is checked, send all jobs to admin email
@@ -1248,75 +1341,81 @@ function notify_job_users($subject, $alarm, $currentval, $sent_emails) {
 			AND gal.jobid > 0
 			AND (gal.last_reported="0000-00-00" OR (ga.repeat_alert>0 AND gal.last_reported<now()))
 			GROUP BY clusterid',
-			array($alarm['id'], $alarm['id'], $alarm['id'], $alarm['id']));
+			array($id, $id, $id, $id));
 
 		if (cacti_sizeof ($cluster_groups)) {
 			foreach ($cluster_groups as $cluster_group) {
 				//ToDo merge follow 4 SQL as two with OR/| expression.
-				$job_items = db_fetch_assoc_prepared ("SELECT gal.*, gj.mailuser, gal.user AS job_user
+				$job_items = db_fetch_assoc_prepared("SELECT gal.*, gj.mailuser, gal.user AS job_user
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs AS gj
-					ON gj.exec_host=gal.host
-					AND gj.clusterid=gal.clusterid
-					AND gj.jobid=gal.jobid
-					AND gj.indexid=gal.indexid
-					AND gj.submit_time=gal.submit_time
+					ON gj.exec_host = gal.host
+					AND gj.clusterid = gal.clusterid
+					AND gj.jobid = gal.jobid
+					AND gj.indexid = gal.indexid
+					AND gj.submit_time = gal.submit_time
 					INNER JOIN gridalarms_alarm AS ga
-					ON ga.id=gal.alarm_id
-					WHERE ga.id= ?
-					AND ga.alarm_alert>0
-					AND gal.type & 2 >0
-					AND gj.clusterid= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+					ON ga.id = gal.alarm_id
+					WHERE ga.id = ?
+					AND ga.alarm_alert > 0
+					AND gal.type & 2 > 0
+					AND gj.clusterid = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 					UNION
 					SELECT gal.*, gj.mailuser, gal.user AS job_user
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs_finished AS gj
-					ON gj.exec_host=gal.host
-					AND gj.clusterid=gal.clusterid
-					AND gj.jobid=gal.jobid
-					AND gj.indexid=gal.indexid
-					AND gj.submit_time=gal.submit_time
+					ON gj.exec_host = gal.host
+					AND gj.clusterid = gal.clusterid
+					AND gj.jobid = gal.jobid
+					AND gj.indexid = gal.indexid
+					AND gj.submit_time = gal.submit_time
 					INNER JOIN gridalarms_alarm AS ga
-					ON ga.id=gal.alarm_id
-					WHERE ga.id= ?
-					AND ga.alarm_alert>0
-					AND gal.type & 2 >0
-					AND gj.clusterid= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+					ON ga.id = gal.alarm_id
+					WHERE ga.id = ?
+					AND ga.alarm_alert > 0
+					AND gal.type & 2 > 0
+					AND gj.clusterid = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 					UNION
 					SELECT gal.*, gj.mailuser, gal.user AS job_user
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs AS gj
-					ON gj.clusterid=gal.clusterid
-					AND gj.jobid=gal.jobid
-					AND gj.indexid=gal.indexid
-					AND gj.submit_time=gal.submit_time
+					ON gj.clusterid = gal.clusterid
+					AND gj.jobid = gal.jobid
+					AND gj.indexid = gal.indexid
+					AND gj.submit_time = gal.submit_time
 					INNER JOIN gridalarms_alarm AS ga
-					ON ga.id=gal.alarm_id
-					WHERE ga.id= ?
-					AND ga.alarm_alert>0
-					AND gal.type & 1 >0
+					ON ga.id = gal.alarm_id
+					WHERE ga.id = ?
+					AND ga.alarm_alert > 0
+					AND gal.type & 1 > 0
 					AND gal.jobid > 0
-					AND gal.clusterid= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+					AND gal.clusterid = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 					UNION
 					SELECT gal.*, gj.mailuser, gal.user AS job_user
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs_finished AS gj
-					ON gj.clusterid=gal.clusterid
-					AND gj.jobid=gal.jobid
-					AND gj.indexid=gal.indexid
-					AND gj.submit_time=gal.submit_time
+					ON gj.clusterid = gal.clusterid
+					AND gj.jobid = gal.jobid
+					AND gj.indexid = gal.indexid
+					AND gj.submit_time = gal.submit_time
 					INNER JOIN gridalarms_alarm AS ga
 					ON ga.id=gal.alarm_id
-					WHERE ga.id= ?
-					AND ga.alarm_alert>0
-					AND gal.type & 1 >0
+					WHERE ga.id = ?
+					AND ga.alarm_alert > 0
+					AND gal.type & 1 > 0
 					AND gal.jobid > 0
-					AND gal.clusterid= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))",
-					array($alarm['id'], $cluster_group['clusterid'], $alarm['id'], $cluster_group['clusterid'], $alarm['id'], $cluster_group['clusterid'], $alarm['id'], $cluster_group['clusterid']));
+					AND gal.clusterid = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))",
+					array(
+						$id, $cluster_group['clusterid'],
+						$id, $cluster_group['clusterid'],
+						$id, $cluster_group['clusterid'],
+						$id, $cluster_group['clusterid']
+					)
+				);
 
 				// send Email per cluster
 				$gal_id_array = do_items($subject, $alarm, $currentval, $job_items, $columns, true, $sent_emails);
@@ -1336,143 +1435,144 @@ function notify_job_users($subject, $alarm, $currentval, $sent_emails) {
 		$cluster_user_groups = db_fetch_assoc_prepared("SELECT gj.clusterid, gj.user AS job_user, count(*)
 			FROM gridalarms_alarm_log_items AS gal
 			INNER JOIN grid_jobs AS gj
-			ON gj.exec_host=gal.host
-			AND gj.clusterid=gal.clusterid
-			AND gj.jobid=gal.jobid
-			AND gj.indexid=gal.indexid
-			AND gj.submit_time=gal.submit_time
+			ON gj.exec_host = gal.host
+			AND gj.clusterid = gal.clusterid
+			AND gj.jobid = gal.jobid
+			AND gj.indexid = gal.indexid
+			AND gj.submit_time = gal.submit_time
 			INNER JOIN gridalarms_alarm AS ga
-			ON ga.id=gal.alarm_id
-			WHERE ga.id= ?
-			AND ga.alarm_alert>0
-			AND gal.type & 2 >0
-			AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+			ON ga.id = gal.alarm_id
+			WHERE ga.id = ?
+			AND ga.alarm_alert > 0
+			AND gal.type & 2 > 0
+			AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 			GROUP BY clusterid,job_user
 			UNION
 			SELECT gj.clusterid, gj.user AS job_user, count(*)
 			FROM gridalarms_alarm_log_items AS gal
 			INNER JOIN grid_jobs_finished AS gj
-			ON gj.exec_host=gal.host
-			AND gj.clusterid=gal.clusterid
-			AND gj.jobid=gal.jobid
-			AND gj.indexid=gal.indexid
-			AND gj.submit_time=gal.submit_time
+			ON gj.exec_host = gal.host
+			AND gj.clusterid = gal.clusterid
+			AND gj.jobid = gal.jobid
+			AND gj.indexid = gal.indexid
+			AND gj.submit_time = gal.submit_time
 			INNER JOIN gridalarms_alarm AS ga
 			ON ga.id=gal.alarm_id
-			WHERE ga.id= ?
-			AND ga.alarm_alert>0
-			AND gal.type & 2 >0
-			AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+			WHERE ga.id = ?
+			AND ga.alarm_alert > 0
+			AND gal.type & 2 > 0
+			AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 			GROUP BY clusterid,job_user
 			UNION
 			SELECT gal.clusterid,gal.user AS job_user,count(*)
 			FROM gridalarms_alarm_log_items AS gal
 			INNER JOIN grid_jobs AS gj
-			ON gj.clusterid=gal.clusterid
-			AND gj.jobid=gal.jobid
-			AND gj.indexid=gal.indexid
-			AND gj.submit_time=gal.submit_time
+			ON gj.clusterid = gal.clusterid
+			AND gj.jobid = gal.jobid
+			AND gj.indexid = gal.indexid
+			AND gj.submit_time = gal.submit_time
 			INNER JOIN gridalarms_alarm AS ga
-			ON ga.id=gal.alarm_id
-			WHERE ga.id= ?
-			AND ga.alarm_alert>0
-			AND gal.type & 1 >0
+			ON ga.id = gal.alarm_id
+			WHERE ga.id = ?
+			AND ga.alarm_alert > 0
+			AND gal.type & 1 > 0
 			AND gal.jobid > 0
-			AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+			AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 			GROUP BY clusterid,job_user
 			UNION
 			SELECT gal.clusterid,gal.user AS job_user,count(*)
 			FROM gridalarms_alarm_log_items AS gal
 			INNER JOIN grid_jobs_finished AS gj
-			ON gj.clusterid=gal.clusterid
-			AND gj.jobid=gal.jobid
-			AND gj.indexid=gal.indexid
-			AND gj.submit_time=gal.submit_time
+			ON gj.clusterid = gal.clusterid
+			AND gj.jobid = gal.jobid
+			AND gj.indexid = gal.indexid
+			AND gj.submit_time = gal.submit_time
 			INNER JOIN gridalarms_alarm AS ga
-			ON ga.id=gal.alarm_id
-			WHERE ga.id= ?
-			AND ga.alarm_alert>0
-			AND gal.type & 1 >0
+			ON ga.id = gal.alarm_id
+			WHERE ga.id = ?
+			AND ga.alarm_alert > 0
+			AND gal.type & 1 > 0
 			AND gal.jobid > 0
-			AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+			AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 			GROUP BY clusterid,job_user",
-			array($alarm['id'], $alarm['id'], $alarm['id'], $alarm['id']));
+			array($id, $id, $id, $id));
 
 		if (cacti_sizeof ($cluster_user_groups)) {
 			foreach ($cluster_user_groups as $cluster_user_group) {
-				$job_items = db_fetch_assoc_prepared ("SELECT gal.*, gj.mailuser, gal.user AS job_user
+				$job_items = db_fetch_assoc ("SELECT gal.*, gj.mailuser, gal.user AS job_user
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs AS gj
-					ON gj.exec_host=gal.host
-					AND gj.clusterid=gal.clusterid
-					AND gj.jobid=gal.jobid
-					AND gj.indexid=gal.indexid
-					AND gj.submit_time=gal.submit_time
+					ON gj.exec_host = gal.host
+					AND gj.clusterid = gal.clusterid
+					AND gj.jobid = gal.jobid
+					AND gj.indexid = gal.indexid
+					AND gj.submit_time = gal.submit_time
 					INNER JOIN gridalarms_alarm AS ga
-					ON ga.id=gal.alarm_id
-					WHERE ga.id= ?
-					AND ga.alarm_alert>0
-					AND gal.type & 2 >0
-					AND gj.clusterid= ?
-					AND gj.user= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+					ON ga.id = gal.alarm_id
+					WHERE ga.id = ?
+					AND ga.alarm_alert > 0
+					AND gal.type & 2 > 0
+					AND gj.clusterid = ?
+					AND gj.user = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 					UNION
 					SELECT gal.*, gj.mailuser, gal.user AS job_user
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs_finished AS gj
-					ON gj.exec_host=gal.host
-					AND gj.clusterid=gal.clusterid
-					AND gj.jobid=gal.jobid
-					AND gj.indexid=gal.indexid
-					AND gj.submit_time=gal.submit_time
+					ON gj.exec_host = gal.host
+					AND gj.clusterid = gal.clusterid
+					AND gj.jobid = gal.jobid
+					AND gj.indexid = gal.indexid
+					AND gj.submit_time = gal.submit_time
 					INNER JOIN gridalarms_alarm AS ga
-					ON ga.id=gal.alarm_id
-					WHERE ga.id= ?
-					AND ga.alarm_alert>0
-					AND gal.type & 2 >0
-					AND gj.clusterid= ?
-					AND gj.user= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+					ON ga.id = gal.alarm_id
+					WHERE ga.id = ?
+					AND ga.alarm_alert > 0
+					AND gal.type & 2 > 0
+					AND gj.clusterid = ?
+					AND gj.user = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 					UNION
 					SELECT gal.*, gj.mailuser, gal.user AS job_user
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs AS gj
-					ON gj.clusterid=gal.clusterid
-					AND gj.jobid=gal.jobid
-					AND gj.indexid=gal.indexid
-					AND gj.submit_time=gal.submit_time
+					ON gj.clusterid = gal.clusterid
+					AND gj.jobid = gal.jobid
+					AND gj.indexid = gal.indexid
+					AND gj.submit_time = gal.submit_time
 					INNER JOIN gridalarms_alarm AS ga
-					ON ga.id=gal.alarm_id
-					WHERE ga.id= ?
-					AND ga.alarm_alert>0
-					AND gal.type & 1 >0
+					ON ga.id = gal.alarm_id
+					WHERE ga.id = ?
+					AND ga.alarm_alert > 0
+					AND gal.type & 1 > 0
 					AND gal.jobid > 0
-					AND gal.clusterid= ?
-					AND gal.user= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+					AND gal.clusterid = ?
+					AND gal.user = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 					UNION
 					SELECT gal.*, gj.mailuser, gal.user AS job_user
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs_finished AS gj
-					ON gj.clusterid=gal.clusterid
-					AND gj.jobid=gal.jobid
-					AND gj.indexid=gal.indexid
-					AND gj.submit_time=gal.submit_time
+					ON gj.clusterid = gal.clusterid
+					AND gj.jobid = gal.jobid
+					AND gj.indexid = gal.indexid
+					AND gj.submit_time = gal.submit_time
 					INNER JOIN gridalarms_alarm AS ga
-					ON ga.id=gal.alarm_id
-					WHERE ga.id= ?
-					AND ga.alarm_alert>0
-					AND gal.type & 1 >0
+					ON ga.id = gal.alarm_id
+					WHERE ga.id = ?
+					AND ga.alarm_alert > 0
+					AND gal.type & 1 > 0
 					AND gal.jobid > 0
-					AND gal.clusterid= ?
-					AND gal.user= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))",
+					AND gal.clusterid = ?
+					AND gal.user = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))",
 					array(
-						$alarm['id'],$cluster_user_group['clusterid'],$cluster_user_group['job_user'],
-						$alarm['id'],$cluster_user_group['clusterid'],$cluster_user_group['job_user'],
-						$alarm['id'],$cluster_user_group['clusterid'],$cluster_user_group['job_user'],
-						$alarm['id'],$cluster_user_group['clusterid'],$cluster_user_group['job_user']
-					));
+						$id, $cluster_user_group['clusterid'], $cluster_user_group['job_user'],
+						$id, $cluster_user_group['clusterid'], $cluster_user_group['job_user'],
+						$id, $cluster_user_group['clusterid'], $cluster_user_group['job_user'],
+						$id, $cluster_user_group['clusterid'], $cluster_user_group['job_user'],
+					)
+				);
 
 				// send emails per cluster and user.
 				$gal_id_array = do_items($subject, $alarm, $currentval, $job_items, $columns, false, $sent_emails);
@@ -1486,76 +1586,122 @@ function notify_job_users($subject, $alarm, $currentval, $sent_emails) {
 		}
 
 		// Get job items for host based alerts not associated with a job directly
-		$cluster_hosts = db_fetch_assoc_prepared("SELECT gal.id, gal.clusterid, gal.host AS host, count(*)
+		$cluster_hosts = db_fetch_assoc_prepared("SELECT gal.id, gal.clusterid, gal.host AS host, COUNT(*)
 			FROM gridalarms_alarm_log_items AS gal
 			INNER JOIN gridalarms_alarm AS ga
-			ON ga.id=gal.alarm_id
-			WHERE ga.id= ?
-			AND gal.host!=''
-			AND gal.jobid=0
-			AND ga.alarm_alert>0
-			AND gal.type & 2 >0
-			AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
-			GROUP BY clusterid,host", array($alarm['id']));
+			ON ga.id = gal.alarm_id
+			WHERE ga.id = ?
+			AND gal.host != ''
+			AND gal.jobid = 0
+			AND ga.alarm_alert > 0
+			AND gal.type & 2 > 0
+			AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
+			GROUP BY clusterid,host", array($id));
 
 		$newcols = array(
-			'host' => 'Host',
-			'clustername' => 'Cluster Name',
-			'jobid' => 'JobID',
-			'indexid' => 'Job Index',
-			'submit_time' => 'Submit Time',
-			'user' => 'Job User'
+			'host' => array(
+				'display_name' => __('Host', 'gridalarms'),
+				'type'         => 'string',
+				'align'        => 'left',
+				'units'        => '',
+				'digits'       => '0',
+				'autoscale'    => '1'
+			),
+			'clustername' => array(
+				'display_name' => __('Cluster Name', 'gridalarms'),
+				'type'         => 'string',
+				'align'        => 'left',
+				'units'        => '',
+				'digits'       => '0',
+				'autoscale'    => '1'
+			),
+			'jobid' => array(
+				'display_name' => __('JobID', 'gridalarms'),
+				'type'         => 'string',
+				'align'        => 'left',
+				'units'        => '',
+				'digits'       => '0',
+				'autoscale'    => '1'
+			),
+			'indexid' => array(
+				'display_name' => __('Job Index', 'gridalarms'),
+				'type'         => 'string',
+				'align'        => 'left',
+				'units'        => '',
+				'digits'       => '0',
+				'autoscale'    => '1'
+			),
+			'submit_time' => array(
+				'display_name' => __('Submit Time', 'gridalarms'),
+				'type'         => 'string',
+				'align'        => 'left',
+				'units'        => '',
+				'digits'       => '0',
+				'autoscale'    => '1'
+			),
+			'user' => array(
+				'display_name' => __('Job User', 'gridalarms'),
+				'type'         => 'string',
+				'align'        => 'left',
+				'units'        => '',
+				'digits'       => '0',
+				'autoscale'    => '1'
+			),
 		);
 
 		$job_items = array();
 
 		if (cacti_sizeof($cluster_hosts)) {
 			foreach ($cluster_hosts as $ch) {
-				$job_items += db_fetch_assoc_prepared ("SELECT '" . $ch['id'] . "' AS id, gj.clusterid, gj.exec_host AS host,
+				$job_items += db_fetch_assoc_prepared("SELECT '" . $ch['id'] . "' AS id, gj.clusterid, gj.exec_host AS host,
 					gc.clustername AS clustername, gj.jobid, gj.indexid, gj.submit_time, gj.user AS job_user, gj.mailuser
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs AS gj
-					ON gj.exec_host=gal.host
-					AND gj.clusterid=gal.clusterid
+					ON gj.exec_host = gal.host
+					AND gj.clusterid = gal.clusterid
 					LEFT JOIN grid_jobs_jobhosts AS gjh
-					ON gj.clusterid=gjh.clusterid
-					AND gj.jobid=gjh.jobid
-					AND gj.indexid=gjh.indexid
-					AND gj.submit_time=gjh.submit_time
+					ON gj.clusterid = gjh.clusterid
+					AND gj.jobid = gjh.jobid
+					AND gj.indexid = gjh.indexid
+					AND gj.submit_time = gjh.submit_time
 					INNER JOIN gridalarms_alarm AS ga
 					ON ga.id=gal.alarm_id
 					INNER JOIN grid_clusters AS gc
-					ON gc.clusterid=gj.clusterid
-					WHERE ga.id= ?
+					ON gc.clusterid = gj.clusterid
+					WHERE ga.id = ?
 					AND gjh.jobid IS NULL
-					AND ga.alarm_alert>0
-					AND gal.type & 2 >0
-					AND gj.clusterid= ?
-					AND gj.exec_host= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))
+					AND ga.alarm_alert > 0
+					AND gal.type & 2 > 0
+					AND gj.clusterid = ?
+					AND gj.exec_host = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))
 					UNION
 					SELECT '" . $ch['id'] . "' AS id, gj.clusterid, gjh.exec_host AS host, gc.clustername AS clustername,
 					gj.jobid, gj.indexid, gj.submit_time, gj.user AS job_user, gj.mailuser
 					FROM gridalarms_alarm_log_items AS gal
 					INNER JOIN grid_jobs_jobhosts AS gjh
-					ON gal.clusterid=gjh.clusterid
-					AND gal.host=gjh.exec_host
+					ON gal.clusterid = gjh.clusterid
+					AND gal.host = gjh.exec_host
 					INNER JOIN grid_jobs AS gj
-					ON gj.clusterid=gjh.clusterid
-					AND gj.jobid=gjh.jobid
-					AND gj.indexid=gjh.indexid
-					AND gj.submit_time=gjh.submit_time
+					ON gj.clusterid = gjh.clusterid
+					AND gj.jobid = gjh.jobid
+					AND gj.indexid = gjh.indexid
+					AND gj.submit_time = gjh.submit_time
 					INNER JOIN gridalarms_alarm AS ga
-					ON ga.id=gal.alarm_id
+					ON ga.id = gal.alarm_id
 					INNER JOIN grid_clusters AS gc
-					ON gc.clusterid=gj.clusterid
-					WHERE ga.id= ?
-					AND ga.alarm_alert>0
-					AND gal.type & 2 >0
-					AND gj.clusterid= ?
-					AND gjh.exec_host= ?
-					AND (gal.last_reported='0000-00-00' OR (ga.repeat_alert>0 AND gal.last_reported<now()))",
-					array($alarm['id'], $ch['clusterid'], $ch['host'], $alarm['id'], $ch['clusterid'], $ch['host']));
+					ON gc.clusterid = gj.clusterid
+					WHERE ga.id = ?
+					AND ga.alarm_alert > 0
+					AND gal.type & 2 > 0
+					AND gj.clusterid = ?
+					AND gjh.exec_host = ?
+					AND (gal.last_reported = '0000-00-00' OR (ga.repeat_alert > 0 AND gal.last_reported < NOW()))",
+					array(
+						$id, $ch['clusterid'], $ch['host'],
+						$id, $ch['clusterid'], $ch['host']
+					)
+				);
 			}
 
 			if (cacti_sizeof($job_items)) {
@@ -1592,53 +1738,63 @@ function notify_job_users($subject, $alarm, $currentval, $sent_emails) {
 	}
 }
 
-function do_items($subject, $alarm, $currentval, $job_items, $columns, $if_admin, $sent_emails) {
+function do_items(string $subject, array $alarm, mixed $currentval, mixed $job_items, mixed $columns, bool $if_admin, mixed $sent_emails) : bool|array {
 	global $config, $cnn_id;
 
-	//print_r($columns);
-	//print_r($job_items);
-
-	if (empty($job_items)) return;
+	if (empty($job_items)) {
+		return false;
+	}
 
 	/* use thold's base url */
 	$httpurl = read_config_option('base_url');
 
 	$display_text = array();
 
-	foreach ($columns as $c) {
-		$display_text[] = $c;
+	foreach ($columns as $column_name => $data) {
+		$display_text[] = array(
+			'display' => $data['display_name'],
+			'align'   => $data['align']
+		);
 	}
 
 	ob_start();
 
-	$i=0;
+	$i = 0;
+
 	/* build new header */
-	html_start_box(__('First %s Threshold Breaching Items', read_config_option('gridalarm_alert_limit')), '100%', '', '3', 'center', '');
+	html_start_box(__('First %s Alert Breaching Items', read_config_option('gridalarm_alert_limit')), '100%', '', '3', 'center', '');
+
 	html_header($display_text);
 
 	foreach ($job_items as $item) {
 		form_alternate_row();
 
 		$j = 1;
-		foreach ($columns as $column_name => $display_name) {
+		foreach ($columns as $column_name => $data) {
+			if ($data['align'] == '') {
+				$data['align'] = 'left';
+			}
+
+			$class = $data['align'];
+
 			switch(strtolower($column_name)) {
 			case 'user':
 			case 'username':
 				if (isset($item['clusterid'])) {
-					print "<td><a href='" . html_escape($httpurl . 'plugins/grid/grid_busers.php?query=1&clusterid=' .
-						$item['clusterid'] . '&filter=' . $item['job_user']) . "'>" . $item['job_user'] . "</a></td>\n";
+					print "<td class='$class nowrap'><a href='" . html_escape($httpurl . 'plugins/grid/grid_busers.php?query=1&clusterid=' .
+						$item['clusterid'] . '&filter=' . $item['job_user']) . "'>" . $item['job_user'] . "</a></td>";
 				} else {
-					print '<td>' . (isset($item['job_user']) ? $item['job_user']:'Not Found') . "</td>\n";
+					print "<td class='$class nowrap'>" . (isset($item['job_user']) ? $item['job_user']:__('Not Found', 'gridalarms')) . "</td>";
 				}
 
 				break;
 			case 'jobid':
 				if (isset($item['indexid']) && isset($item['submit_time']) && isset($item['clusterid'])) {
-					print "<td><a href='" . html_escape($httpurl . 'plugins/grid/grid_bjobs.php?query=1&action=viewjob&clusterid=' .
+					print "<td class='$class nowrap'><a href='" . html_escape($httpurl . 'plugins/grid/grid_bjobs.php?query=1&action=viewjob&clusterid=' .
 						$item['clusterid'] . '&indexid=' . $item['indexid'] . '&jobid=' . $item['jobid'] . '&submit_time=' .
-						strtotime($item['submit_time']) . "' title='". $item['jobid']) . "'>" .	$item['jobid'] . "</a></td>\n";
+						strtotime($item['submit_time']) . "' title='". $item['jobid']) . "'>" .	$item['jobid'] . "</a></td>";
 				} else {
-					print '<td>' . (isset($item['jobid']) ? $item['jobid']:'Not Found') . "</td>\n";
+					print "<td class='$class nowrap'>" . (isset($item['jobid']) ? $item['jobid']:__('Not Found', 'gridalarms')) . "</td>";
 				}
 
 				break;
@@ -1647,10 +1803,10 @@ function do_items($subject, $alarm, $currentval, $job_items, $columns, $if_admin
 				$queue = $item['column' . substr('0' . $j, -2)];
 
 				if (isset($item['clusterid'])) {
-					print "<td><a href='" . html_escape($httpurl . 'plugins/grid/grid_bqueues.php?action=&clusterid=' .
-						$item['clusterid'] . '&filter=' . $queue) . "'>$queue</a></td>\n";
+					print "<td class='$class nowrap'><a href='" . html_escape($httpurl . 'plugins/grid/grid_bqueues.php?action=&clusterid=' .
+						$item['clusterid'] . '&filter=' . $queue) . "'>$queue</a></td>";
 				} else {
-					print "<td>$queue</td>\n";
+					print "<td class='$class nowrap'>$queue</td>";
 				}
 
 				break;
@@ -1658,7 +1814,7 @@ function do_items($subject, $alarm, $currentval, $job_items, $columns, $if_admin
 			case 'hostname':
 			case 'host':
 				if (isset($item['column' . substr('0' . $j, -2)])) {
-					$host = ($item['column' . substr('0' . $j, -2)] != 'NULL' ? $item['column' . substr('0' . $j, -2)]:'Not Found');
+					$host = ($item['column' . substr('0' . $j, -2)] != 'NULL' ? $item['column' . substr('0' . $j, -2)]:__('Not Found', 'gridalarms'));
 				} elseif (isset($item['hostname'])) {
 					$host = $item['hostname'];
 				} elseif (isset($item['exec_host'])) {
@@ -1668,20 +1824,20 @@ function do_items($subject, $alarm, $currentval, $job_items, $columns, $if_admin
 				}
 
 				if (isset($item['clusterid'])) {
-					print "<td><a href='" . html_escape($httpurl . 'plugins/grid/grid_bzen.php?action=zoom&clusterid=' .
-					$item['clusterid'] . '&exec_host=' . $host) . "'>" . grid_strip_domain($host) . "</a></td>\n";
+					print "<td class='$class nowrap'><a href='" . html_escape($httpurl . 'plugins/grid/grid_bzen.php?action=zoom&clusterid=' .
+					$item['clusterid'] . '&exec_host=' . $host) . "'>" . grid_strip_domain($host) . "</a></td>";
 				} else {
-					print '<td>' . grid_strip_domain($host) . "</td>\n";
+					print "<td class='$class nowrap'>" . grid_strip_domain($host) . "</td>";
 				}
 
 				break;
 			default:
 				if (isset($item['column' . substr('0' . $j, -2)])) {
-					print '<td>' . $item['column' . substr('0' . $j, -2)] . "</td>\n";
+					print "<td class='$class nowrap'>" . $item['column' . substr('0' . $j, -2)] . "</td>";
 				} elseif (isset($item[$column_name])) {
-					print '<td>' . $item[$column_name] . "</td>\n";
+					print "<td class='$class nowrap'>" . html_escape($item[$column_name]) . "</td>";
 				} else {
-					print "<td>Not Found</td>\n";
+					print "<td class='$class nowrap'>" . __('Not Found', 'gridalarms') . "</td>";
 				}
 				break;
 			}
@@ -1696,30 +1852,32 @@ function do_items($subject, $alarm, $currentval, $job_items, $columns, $if_admin
 
 	//get the new alert message content
 	$email_content = ob_get_clean();
-	$new_msg = gridalarms_text_replace($alarm['email_body'], $currentval, $alarm, $email_content);
+	$new_msg       = gridalarms_text_replace($alarm['email_body'], $currentval, $alarm, $email_content);
 
 	/* obtain user emails, index is clusterid_user */
 	$email_addresses = get_user_emails($job_items, $if_admin, $sent_emails);
-	$email_list = implode (',',$email_addresses);
+	$email_list      = implode (',', $email_addresses);
+
 	gridalarms_debug("email_addresses = '" . $email_list ."'");
 	//gridalarms_debug(str_replace("\n","",$new_msg));
 
 	if (trim($email_list) != '') {
-		alarm_mail($email_list, '', $subject, $new_msg);
+		alarm_mail($email_list, '', $subject, $new_msg, $alarm['format_file']);
 	}
 
 	$gal_id_array = array();
+
 	foreach ($job_items as $item) {
 		$gal_id_array[$item['id']] = $item['id'];
 	}
 
-	return $gal_id_array ;
+	return $gal_id_array;
 }
 
-function get_user_emails($ajobs,$if_admin, $sent_emails='') {
-	$emails = array();
+function get_user_emails(array $ajobs, bool $if_admin, string $sent_emails = '') : array {
+	$emails        = array();
 	$email_domains = array();
-	$method = read_config_option('gridalarm_user_map');
+	$method        = read_config_option('gridalarm_user_map');
 
 	if (cacti_sizeof($ajobs)) {
 		foreach ($ajobs as $j) {
@@ -1779,29 +1937,32 @@ function get_user_emails($ajobs,$if_admin, $sent_emails='') {
 		}
 	}
 
-	//remove duplicate emails from sent emails
+	/* remove duplicate emails from sent emails */
 	if (!empty($sent_emails)) {
 		$sent_emails_array = explode(',', $sent_emails);
+
 		foreach ($emails as $new_email_key => $new_email_value) {
 			if (array_search(strtolower($new_email_value), array_map('strtolower', $sent_emails_array)) !== false) {
 				unset($emails[$new_email_key]);
 			}
 		}
 	}
+
 	return $emails;
 }
 
 /**
  * function to check all alarms
- * @param 					- none
- * @returns					- total alarms checked
+ *
+ * @return int|bool total alarms checked
  */
-function gridalarms_check_all_alarms() {
+function gridalarms_check_all_alarms() : int|bool {
 	global $config;
 
 	// Do not proceed if we have chosen to globally disable all alerts
 	if (read_config_option('thold_disable_all') == 'on') {
 		gridalarms_debug('Grid Alert checking is disabled globally');
+
 		return false;
 	}
 
@@ -1813,7 +1974,8 @@ function gridalarms_check_all_alarms() {
 	$total_alarms = cacti_sizeof($alarms);
 
 	gridalarms_debug("START  - Processing $total_alarms Alert");
-	api_plugin_hook('gridalarms_reset_hostsalarm');
+
+	api_plugin_hook_function('gridalarms_reset_hostsalarm');
 
 	if (cacti_sizeof($alarms)) {
 		foreach ($alarms as $alarm) {
@@ -1829,11 +1991,13 @@ function gridalarms_check_all_alarms() {
 
 /**
  * sets the pollers environment with gridalarm environment variables prior to script launch
- * @param $currentval		- the alarms current value
- * @param $alarm			- the alarm to be used to construct the environment
- * @returns					- total alarms checked
+ *
+ * @param  mixed $currentval the alarms current value
+ * @param  array $alarm the alarm to be used to construct the environment
+ *
+ * @return void
  */
-function gridalarms_set_execenv($currentval, $alarm) {
+function gridalarms_set_execenv(mixed $currentval, array $alarm) : void {
 	/* the current values */
 	putenv('GALERT_NAME=' . $alarm['name']);
 	putenv('GALERT_ID='   . $alarm['id']);
@@ -1851,15 +2015,14 @@ function gridalarms_set_execenv($currentval, $alarm) {
 	putenv('GALERT_ITEMS_HEADER=' . get_alarm_breach_details_headers_for_script($alarm));
 	putenv('GALERT_ITEMS_LIST='   . get_alarm_breach_details_for_script($alarm));
 	putenv('GALERT_ITEMS_COLUMN=' . get_alarm_breach_details_columns_for_script($alarm));
-
 }
 
 /**
  * the main function that spawns the various alerts
- * @param 					- none
- * @returns					- null
+ *
+ * @return void
  */
-function gridalarms_alarm_poller () {
+function gridalarms_alarm_poller() : void {
 	/* record the start time */
 	$start = microtime(true);
 
@@ -1872,14 +2035,14 @@ function gridalarms_alarm_poller () {
 	$end = microtime(true);
 
 	/* log statistics */
-	$gridalarms_alarm_stats = sprintf('Time:%01.4f Alerts:%s', $end - $start, ($alarms === false ? 'checking disabled' : $alarms));
+	$gridalarms_alarm_stats = sprintf('Time:%01.4f Alerts:%s', $end - $start, $alarms);
 
 	cacti_log('GRIDALERTS STATS: ' . $gridalarms_alarm_stats, false, 'SYSTEM');
 
 	set_config_option('stats_gridalarms_alarm', $gridalarms_alarm_stats);
 }
 
-function alarm_cacti_log($string) {
+function alarm_cacti_log(string $string) : void {
 	global $config;
 
 	$environ = 'ALERT';
@@ -1952,11 +2115,14 @@ function alarm_cacti_log($string) {
 
 /**
  * logs events for the alarm for later reference by the operator
- * @param $save				- the cacti specific save array for the insert
- * @returns					- null
+ *
+ * @param array $save the cacti specific save array for the insert
+ *
+ * @return array
  */
-function alarm_log($save) {
+function alarm_log(array $save) : array {
 	$save['id'] = 0;
+
 	if (read_config_option('thold_log_cacti') == 'on') {
 		$alarm = db_fetch_row_prepared('SELECT *
 			FROM gridalarms_alarm
@@ -1976,23 +2142,27 @@ function alarm_log($save) {
 
 		$desc .= '  Type: ' . $types[$alarm['alarm_type']];
 		$desc .= '  Enabled: ' . $alarm['alarm_enabled'];
+
 		switch ($alarm['alarm_type']) {
-		case 0:
-			$desc .= '  Current: ' . $save['current'];
-			$desc .= '  High: ' . $alarm['alarm_hi'];
-			$desc .= '  Low: ' . $alarm['alarm_low'];
-			$desc .= '  Trigger: ' . plugin_alarm_duration_convert($alarm['alarm_fail_trigger'], 'alert');
-			break;
-		case 1:
-			$desc .= '  Current: ' . $save['current'];
-			break;
-		case 2:
-			$desc .= '  Current: ' . $save['current'];
-			$desc .= '  High: ' . $alarm['time_hi'];
-			$desc .= '  Low: ' . $alarm['time_low'];
-			$desc .= '  Trigger: ' . $alarm['time_fail_trigger'];
-			$desc .= '  Time: ' . plugin_alarm_duration_convert($alarm['time_fail_length'], 'time');
-			break;
+			case 0:
+				$desc .= '  Current: ' . $save['current'];
+				$desc .= '  High: ' . $alarm['alarm_hi'];
+				$desc .= '  Low: ' . $alarm['alarm_low'];
+				$desc .= '  Trigger: ' . plugin_alarm_duration_convert($alarm['alarm_fail_trigger'], 'alert');
+
+				break;
+			case 1:
+				$desc .= '  Current: ' . $save['current'];
+
+				break;
+			case 2:
+				$desc .= '  Current: ' . $save['current'];
+				$desc .= '  High: ' . $alarm['time_hi'];
+				$desc .= '  Low: ' . $alarm['time_low'];
+				$desc .= '  Trigger: ' . $alarm['time_fail_trigger'];
+				$desc .= '  Time: ' . plugin_alarm_duration_convert($alarm['time_fail_length'], 'time');
+
+				break;
 		}
 
 		$desc .= '  SentTo: ' . $save['emails'];
@@ -2005,19 +2175,25 @@ function alarm_log($save) {
 	unset($save['emails']);
 
 	if (isset($save['details'])) {
-		$save['details'] = base64url_encode($save['details']);
+		$save['details'] = rtm_base64url_encode($save['details']);
 	}
 
 	$id = sql_save($save, 'gridalarms_alarm_log');
+
+	api_plugin_hook_function('gridalarms_action', $save);
+
+	return $save;
 }
 
 /**
  * logs acknowledgement messages from alarms that have been acknowledged
- * @param $id				- the id of the alarm to be acknowledged
- * @param $desc				- the message that was entered by the admin
- * @returns					- null
+ *
+ * @param int    $id the id of the alarm to be acknowledged
+ * @param string $desc the message that was entered by the admin
+ *
+ * @return void
  */
-function alarm_ack_logging($id, $desc, $email = false) {
+function alarm_ack_logging(int $id, string $desc, bool $email = false) : void {
 	$alarm = get_alarm_by_id($id);
 
 	if (isset($_SESSION['sess_user_id'])) {
@@ -2046,14 +2222,14 @@ function alarm_ack_logging($id, $desc, $email = false) {
 	}
 
 	alarm_log(array(
-		'type' => $alarm['alarm_type'],
-		'time' => time(),
-		'alarm_id' => $id,
+		'type'        => $alarm['alarm_type'],
+		'time'        => time(),
+		'alarm_id'    => $id,
 		'alarm_value' => '',
-		'current' => $alarm['lastread'],
-		'status' => 99,
+		'current'     => $alarm['lastread'],
+		'status'      => 99,
 		'description' => $desc,
-		'emails' => '')
+		'emails'      => '')
 	);
 
 	if ($email) {
@@ -2065,7 +2241,7 @@ function alarm_ack_logging($id, $desc, $email = false) {
 		$message .= '<tr><td>' . $desc . '</td></tr>';
 
 		if (trim($alarm_emails) != '') {
-			alarm_mail($alarm_emails, '', $subject, $message);
+			alarm_mail($alarm_emails, '', $subject, $message, $alarm['format_file']);
 		}
 	}
 
@@ -2076,10 +2252,12 @@ function alarm_ack_logging($id, $desc, $email = false) {
 
 /**
  * get the current threshold value for a script based data source
- * @param $alarm			- the alarm to run
- * @returns					- the return value
+ *
+ * @param  array $alarm the alarm to run
+ *
+ * @return mixed the return value
  */
-function get_current_value_by_script($alarm) {
+function get_current_value_by_script(array $alarm) : mixed {
 	$expression = get_expression_by_id($alarm['expression_id']);
 
 	if (cacti_sizeof($expression)) {
@@ -2103,10 +2281,12 @@ function get_current_value_by_script($alarm) {
 
 /**
  * get the current threshold value for an expression based data source
- * @param $alarm			- the alarm to run
- * @returns					- the return value
+ *
+ * @param  array $alarm the alarm to run
+ *
+ * @return mixed the return value
  */
-function get_current_value_by_expression($alarm) {
+function get_current_value_by_expression(array $alarm) : mixed {
 	global $aggregation;
 
 	$expression     = get_expression_by_id($alarm['expression_id']);
@@ -2152,10 +2332,12 @@ function get_current_value_by_expression($alarm) {
 
 /**
  * get the current threshold value for an sql query based data source
- * @param $alarm			- the alarm to run
- * @returns					- the return value
+ *
+ * @param  array $alarm the alarm to run
+ *
+ * @return mixed the return value
  */
-function get_current_value_by_sql($alarm) {
+function get_current_value_by_sql(array $alarm) : mixed {
 	global $aggregation;
 
 	$expression = get_expression_by_id($alarm['expression_id']);
@@ -2196,10 +2378,12 @@ function get_current_value_by_sql($alarm) {
 
 /**
  * get the name of the cluster for a specific clusterid
- * @param $clusterid		- the clusterid to check
- * @returns					- the name of the cluster
+ *
+ * @param  int $clusterid the clusterid to check
+ *
+ * @return bool|string the name of the cluster
  */
-function get_clustername($clusterid) {
+function get_clustername(int $clusterid) : bool|string {
 	return db_fetch_cell_prepared('SELECT clustername
 		FROM grid_clusters
 		WHERE clusterid = ?',
@@ -2208,27 +2392,27 @@ function get_clustername($clusterid) {
 
 /**
  * get an associative array of clusterid, clustername combinations
- * @param 					- none
- * @returns					- array of all clusterids, and clusternames
+ *
+ * @return mixed all clusters names and ids
  */
-function get_clusters() {
+function get_clusters() : bool|array {
 	return db_fetch_assoc('SELECT clusterid, clustername
 		FROM grid_clusters');
 }
 
 /**
  * create an array of dropdown compatible clusterid/name for Cacti dropdown function
- * @param 					- none
- * @returns					- formatted array for cacti api
+ *
+ * @return array of formatted array for cacti api
  */
-function get_clusters_for_form_dropdown() {
-	$clusters = get_clusters();
+function get_clusters_for_form_dropdown() : array {
+	$clusters     = get_clusters();
 	$cluster_list = array('0' => __('N/A', 'gridalarms'));
 
 	if (cacti_sizeof($clusters)) {
-	foreach ($clusters as $cluster) {
-		$cluster_list[$cluster['clusterid']] = $cluster['clustername'];
-	}
+		foreach ($clusters as $cluster) {
+			$cluster_list[$cluster['clusterid']] = $cluster['clustername'];
+		}
 	}
 
 	return $cluster_list;
@@ -2236,10 +2420,12 @@ function get_clusters_for_form_dropdown() {
 
 /**
  * function to print debug messages to console when running cli's
- * @param $message			- string message with or without trailing line breaks
- * @returns					- null
+ *
+ * @param  string $message string message with or without trailing line breaks
+ *
+ * @return void
  */
-function gridalarms_debug($message) {
+function gridalarms_debug(string $message) : void {
 	global $debug;
 
 	if (defined('CACTI_DATE_TIME_FORMAT')) {
@@ -2255,10 +2441,13 @@ function gridalarms_debug($message) {
 
 /**
  * builds a SQL statment from the expression syntax created for the alert
- * @param $expression_id	- the expression to build syntax for
- * @returns					- null, or formatted sql statment
+ *
+ * @param int    $expression_id the expression to build syntax for
+ @ @param string $where_extra any extra SQL where to use
+ *
+ * @return mixed the sql query
  */
-function build_expression_string_for_sql_from_where($expression_id, $where_extra = '') {
+function build_expression_string_for_sql_from_where(int $expression_id, string $where_extra = '') : string {
 	$items = db_fetch_assoc_prepared('SELECT *
 		FROM gridalarms_expression_item
 		WHERE expression_id = ?
@@ -2268,13 +2457,14 @@ function build_expression_string_for_sql_from_where($expression_id, $where_extra
 	$expression = get_expression_by_id($expression_id);
 
 	$i = 0;
+
 	$gridalarms_expression_string = ' FROM ' . $expression['db_table'];
 
-	if(strlen($where_extra) > 0 || cacti_sizeof($items) > 0){
+	if (strlen($where_extra) > 0 || cacti_sizeof($items) > 0) {
 		$gridalarms_expression_string .= ' WHERE ';
 	}
 
-	if(strlen($where_extra) > 0 && cacti_sizeof($items) > 0){
+	if (strlen($where_extra) > 0 && cacti_sizeof($items) > 0) {
 		$where_extra .= ' AND ';
 	}
 
@@ -2328,10 +2518,13 @@ function build_expression_string_for_sql_from_where($expression_id, $where_extra
 
 /**
  * builds a SQL statment from the expression syntax created for the template
- * @param $expression_id	- the expression to build syntax for
- * @returns					- null, or formatted sql statment
+ *
+ * @param int     $expression_id the expression to build syntax for
+ @ @param string $where_extra any extra SQL where to use
+ *
+ * @return string the formatted sql statment
  */
-function build_template_expression_string_for_sql_from_where($expression_id, $where_extra = '') {
+function build_template_expression_string_for_sql_from_where(int $expression_id, string $where_extra = '') : string {
 	$items = db_fetch_assoc_prepared('SELECT *
 		FROM gridalarms_template_expression_item
 		WHERE expression_id = ?
@@ -2344,11 +2537,11 @@ function build_template_expression_string_for_sql_from_where($expression_id, $wh
 
 	$gridalarms_expression_string = ' FROM ' . $expression['db_table'];
 
-	if(strlen($where_extra) > 0 || cacti_sizeof($items) > 0){
+	if (strlen($where_extra) > 0 || cacti_sizeof($items) > 0) {
 		$gridalarms_expression_string .= ' WHERE ';
 	}
 
-	if(strlen($where_extra) > 0 && cacti_sizeof($items) > 0){
+	if (strlen($where_extra) > 0 && cacti_sizeof($items) > 0) {
 		$where_extra .= ' AND ';
 	}
 
@@ -2401,17 +2594,21 @@ function build_template_expression_string_for_sql_from_where($expression_id, $wh
 
 /**
  * build the expression string for viewing in alert data source page
- * @param $expression_id	- the expression to build syntax for
- * @returns					- string of formatted expression
+ *
+ * @param int     $expression_id the expression to build syntax for
+ *
+ * @return string of formatted expression
  */
-function get_gridalarms_expression_string($expression_id) {
+function get_gridalarms_expression_string(int $expression_id) : string {
 	$items = db_fetch_assoc_prepared('SELECT *
 		FROM gridalarms_expression_item
 		WHERE expression_id = ?
 		ORDER BY sequence',
 		array($expression_id));
 
-	$i = 0; $gridalarms_expression_string = '';
+	$gridalarms_expression_string = '';
+
+	$i = 0;
 
 	if (cacti_sizeof($items)) {
 		foreach ($items as $item) {
@@ -2430,14 +2627,17 @@ function get_gridalarms_expression_string($expression_id) {
 					case 'clusterid':
 					case 'clustername':
 						$gridalarms_expression_string .= '|alert_' . $item['value'] . "|";
+
 						break;
 					default:
 						$gridalarms_expression_string .= '|input_' . $item['value'] . "|";
+
 						break;
 				}
 			} else {
 				$gridalarms_expression_string .= $item['value'];
 			}
+
 			$i++;
 		}
 	}
@@ -2447,17 +2647,21 @@ function get_gridalarms_expression_string($expression_id) {
 
 /**
  * build the expression string for viewing in template data source page
- * @param $expression_id	- the expression to build syntax for
- * @returns					- string of formatted expression
+ *
+ * @param  int    $expression_id the expression to build syntax for
+ *
+ * @return string of formatted expression
  */
-function get_gridalarms_template_expression_string($expression_id) {
+function get_gridalarms_template_expression_string(int $expression_id) : string {
 	$items = db_fetch_assoc_prepared('SELECT *
 		FROM gridalarms_template_expression_item
 		WHERE expression_id = ?
 		ORDER BY sequence',
 		array($expression_id));
 
-	$i = 0; $gridalarms_expression_string = '';
+	$gridalarms_expression_string = '';
+
+	$i = 0;
 
 	if (cacti_sizeof($items)) {
 		foreach ($items as $item) {
@@ -2468,39 +2672,48 @@ function get_gridalarms_template_expression_string($expression_id) {
 			/* string value append quotes */
 			if ($item['type'] == 5) {
 				$gridalarms_expression_string .= "'" . trim($item['value'], '"\'') . "'";
+
 				cacti_log("DEBUG: Value '" . $item['value'] . "', Final '" . $gridalarms_expression_string . "'", false, 'GRIDALERTS', POLLER_VERBOSITY_DEBUG);
 			} elseif ($item['type'] == 3) {
 				$metric = get_template_metric($item['value']);
 				$gridalarms_expression_string .= $metric['name'];
+
 				cacti_log("DEBUG: PValue '" . $item['value'] . "', Final '" . $gridalarms_expression_string . "'", false, 'GRIDALERTS', POLLER_VERBOSITY_DEBUG);
 			} elseif ($item['type'] == 7) {
 				switch($item['value']) {
 					case 'clusterid':
 					case 'clustername':
 						$gridalarms_expression_string .= '|alert_' . $item['value'] . "|";
+
 						break;
 					default:
 						$gridalarms_expression_string .= '|input_' . $item['value'] . "|";
+
 						break;
 				}
 			} else {
-				cacti_log("DEBUG: EValue '" . $item['value'] . "', Final '" . $gridalarms_expression_string . "'", false, 'GRIDALERTS', POLLER_VERBOSITY_DEBUG);
 				$gridalarms_expression_string .= $item['value'];
+
+				cacti_log("DEBUG: EValue '" . $item['value'] . "', Final '" . $gridalarms_expression_string . "'", false, 'GRIDALERTS', POLLER_VERBOSITY_DEBUG);
 			}
+
+			cacti_log("DEBUG: gridalarms_expression_string: $gridalarms_expression_string", false, 'GRIDALERTS', POLLER_VERBOSITY_DEBUG);
+
 			$i++;
 		}
 	}
-	cacti_log("DEBUG: gridalarms_expression_string: $gridalarms_expression_string", false, 'GRIDALERTS', POLLER_VERBOSITY_DEBUG);
 
 	return $gridalarms_expression_string;
 }
 
 /**
  * get all metrics from grid_template_metrics where the metric belongs to a particular table
- * @param $table			- the table to operate on
- * @returns					- array of columns
+ *
+ * @param  string $table the table to operate on
+ *
+ * @return array of columns
  */
-function get_gridalarms_template_metrics($table) {
+function get_gridalarms_template_metrics(string $table) : array {
 	$metrics = db_fetch_assoc_prepared('SELECT id, name
 		FROM gridalarms_template_metric
 		WHERE db_table = ?',
@@ -2519,10 +2732,12 @@ function get_gridalarms_template_metrics($table) {
 
 /**
  * get all column names for a templates expression
- * @param $expression_id	- the table to operate on
- * @returns					- array of columns
+ *
+ * @param  int $expression_id the table to operate on
+ *
+ * @return array of columns
  */
-function get_template_expression_db_columns($expression_id) {
+function get_template_expression_db_columns(int $expression_id) : array {
 	$metric_ids = db_fetch_assoc_prepared('SELECT value
 		FROM gridalarms_template_expression_item
 		WHERE expression_id = ?
@@ -2547,53 +2762,58 @@ function get_template_expression_db_columns($expression_id) {
 
 /**
  * Get expression item from grid_template_expression_item based on id.
- * @param Integer $id
+ *
+ * @param  int   $expression_id The expression id
+ *
+ * @return bool|array Row of expression items or false
  */
-function get_template_expression_item($id) {
+function get_template_expression_item(int $expression_id) : bool|array {
 	return db_fetch_row_prepared('SELECT *
 		FROM gridalarms_template_expression_item
 		WHERE id = ?',
-		array($id));
+		array($expression_id));
 }
 
-function get_template_metrics_from_expression_by_id($id) {
-	$expression = get_template_expression_by_id($id);
+function get_template_metrics_from_expression_by_id(int $expression_id) : bool|array {
+	$expression = get_template_expression_by_id($expression_id);
 
 	if ($expression['ds_type'] == '0') {
 		return get_table_columns($expression['db_table']);
 	} elseif ($expression['ds_type'] == '1') {
-		return get_columns_from_sql($expression['sql_query'], 'template', $id);
+		return get_columns_from_sql($expression['sql_query'], 'template', $expression_id);
+	} else {
+		return false;
 	}
 }
 
-function get_template_metrics_from_expression_by_alarm_id($id) {
-	$alarm = get_template_by_id($id);
-	if (cacti_sizeof($alarm)) {
-		return get_template_metrics_from_expression_by_id($alarm['expression_id']);
-	}
-}
-
-function get_template_expressions() {
+function get_template_expressions() : bool|array {
 	return db_fetch_assoc('SELECT * FROM gridalarms_template_expression');
 }
 
 /**
  * Get expression from grid_template_expression based on id
- * @param Integer $id
+ *
+ * @param  int  $id
+ *
+ * @return array Row of expressions or false
  */
-function get_template_expression_by_id($id) {
+function get_template_expression_by_id(int $expression_id) : bool|array {
 	return db_fetch_row_prepared('SELECT *
 		FROM gridalarms_template_expression
 		WHERE id = ?',
-		array($id));
+		array($expression_id));
 }
 
 /**
  * Get expression from grid_template_expression_by_alarm_id based on an alarm id
- * @param Integer $id
+ *
+ * @param  int $alarm_id
+ *
+ * @return array - An array of a template definition
  */
-function get_template_expression_by_alarm_id($id) {
-	$alarm = get_template_by_id($id);
+function get_template_expression_by_alarm_id(int $alarm_id) : ?array {
+	$alarm = get_template_by_id($alarm_id);
+
 	if (cacti_sizeof($alarm)) {
 		return get_template_expression_by_id($alarm['expression_id']);
 	}
@@ -2601,7 +2821,10 @@ function get_template_expression_by_alarm_id($id) {
 
 /**
  * Get alarm from gridalarms_template based on id
+ *
  * @param Integer $id
+ *
+ * @return array - Row of an alert template
  */
 function get_template_by_id($id) {
 	return db_fetch_row_prepared('SELECT *
@@ -2626,9 +2849,12 @@ function get_all_template_metrics() {
 
 /**
  * Get a metric from the gridalarms_metric table based on id
- * @param Integer $id
+ *
+ * @param  int $id
+ *
+ * @return array - Row of a template metric
  */
-function get_template_metric($id) {
+function get_template_metric(int $id) : bool|array {
 	return db_fetch_row_prepared('SELECT *
 		FROM gridalarms_template_metric
 		WHERE id = ?',
@@ -2637,9 +2863,12 @@ function get_template_metric($id) {
 
 /**
  * Get all metrics from grid_metrics where the metric belongs to a particular table
- * @param String $table
+ *
+ * @param  string $table the table name
+ *
+ * @return array An array of metrics
  */
-function get_gridalarms_metrics($table) {
+function get_gridalarms_metrics(string $table) : array {
 	$metrics = db_fetch_assoc_prepared('SELECT id, name
 		FROM gridalarms_metric
 		WHERE db_table = ?',
@@ -2656,7 +2885,7 @@ function get_gridalarms_metrics($table) {
 	return $metrics_array;
 }
 
-function get_expression_db_columns($expression_id) {
+function get_expression_db_columns(int $expression_id) : array {
 	$metric_ids = db_fetch_assoc_prepared('SELECT value
 		FROM gridalarms_expression_item
 		WHERE expression_id = ?
@@ -2679,53 +2908,56 @@ function get_expression_db_columns($expression_id) {
 
 /**
  * Get expression item from grid_expression_item based on id.
+ *
  * @param Integer $id
+ *
+ * @return array - An row of expression items
  */
-function get_expression_item($id) {
+function get_expression_item(int $id) : bool|array {
 	return db_fetch_row_prepared('SELECT *
 		FROM gridalarms_expression_item
 		WHERE id = ?',
 		array($id));
 }
 
-function get_metrics_from_expression_by_id($id) {
-	$expression = get_expression_by_id($id);
+function get_metrics_from_expression_by_id(int $expression_id) : bool|array{
+	$expression = get_expression_by_id($expression_id);
 
 	if ($expression['ds_type'] == '0') {
 		return get_table_columns($expression['db_table']);
 	} elseif ($expression['ds_type'] == '1') {
-		return get_columns_from_sql($expression['sql_query'], 'alarm', $id);
+		return get_columns_from_sql($expression['sql_query'], 'alarm', $expression_id);
 	}
 }
 
-function get_metrics_from_expression_by_alarm_id($id) {
-	$alarm = get_alarm_by_id($id);
-	if (cacti_sizeof($alarm)) {
-		return get_metrics_from_expression_by_id($alarm['expression_id']);
-	}
-}
-
-function get_expressions() {
+function get_expressions() : bool|array {
 	return db_fetch_assoc('SELECT * FROM gridalarms_expression');
 }
 
 /**
  * Get expression from grid_expression based on id
- * @param Integer $id
+ *
+ * @param  int $expression_id The rexpression to query
+ *
+ * @return array A row of an expression
  */
-function get_expression_by_id($id) {
+function get_expression_by_id(int $expression_id) : bool|array {
 	return db_fetch_row_prepared('SELECT *
 		FROM gridalarms_expression
 		WHERE id = ?',
-		array($id));
+		array($expression_id));
 }
 
 /**
  * Get expression from grid_expression based on an alarm id
- * @param Integer $id
+ *
+ * @param  int $alarm_id the alarm to query
+ *
+ * @return array A row of an expression
  */
-function get_expression_by_alarm_id($id) {
-	$alarm = get_alarm_by_id($id);
+function get_expression_by_alarm_id(int $alarm_id) : bool|array {
+	$alarm = get_alarm_by_id($alarm_id);
+
 	if (cacti_sizeof($alarm)) {
 		return get_expression_by_id($alarm['expression_id']);
 	}
@@ -2733,20 +2965,24 @@ function get_expression_by_alarm_id($id) {
 
 /**
  * Get alarm from gridalarms_expression based on id
- * @param Integer $id
+ *
+ * @param  int   $alarm_id
+ *
+ * @return array A row of an alert
  */
-function get_alarm_by_id($id) {
+function get_alarm_by_id(int $alarm_id) : bool|array {
 	return db_fetch_row_prepared('SELECT *
 		FROM gridalarms_alarm
 		WHERE id = ?',
-		array($id));
+		array($alarm_id));
 }
 
 /**
  * Get all the metrics from the gridalarms_metric table
  */
-function get_all_metrics() {
+function get_all_metrics() : bool|array {
 	$sort_order = '';
+
 	if (isset_request_var('sort_column_array') && cacti_sizeof(get_request_var('sort_column_array')) > 0) {
 		$sort_order =  ' ORDER BY ' . gridalarms_build_order_string(get_request_var('sort_column_array'), get_request_var('sort_direction_array'));
 	}
@@ -2758,20 +2994,23 @@ function get_all_metrics() {
 
 /**
  * Get a metric from the gridalarms_metric table based on id
- * @param Integer $id
+ *
+ * @param  int   $metric_id
+ *
+ * @return array A metric row
  */
-function get_metric($id) {
+function get_metric(int $metric_id) : bool|array {
 	return db_fetch_row_prepared('SELECT *
 		FROM gridalarms_metric
 		WHERE id = ?',
-		array($id));
+		array($metric_id));
 }
 
 /**
  * Get all the tables in the database
  */
-function get_tables_in_db() {
-	$tables = array();
+function get_tables_in_db() : array {
+	$tables       = array();
 	$tables_query = db_fetch_assoc('SHOW TABLES');
 
 	foreach ($tables_query as $table) {
@@ -2788,14 +3027,17 @@ function get_tables_in_db() {
 
 /**
  * Get the table columns for the specified table
- * @param Array $table
+ *
+ * @param  string $table
+ *
+ * @return array The table columns
  */
-function get_table_columns($table) {
+function get_table_columns(string $table) : bool|array {
 	if (!isset($table) || empty($table) || $table == '') {
 		return array();
 	}
 
-	$table_columns = array();
+	$table_columns       = array();
 	$table_columns_query = db_fetch_assoc('DESCRIBE ' . $table);
 
 	foreach ($table_columns_query as $column) {
@@ -2809,9 +3051,15 @@ function get_table_columns($table) {
 
 /**
  * Get the table columns for the specified table
- * @param Array $table
+ *
+ * @param  int    $expression_id The expression to search
+ * @param  string $table The table to search
+ * @param  string $type The type of query
+ * @param  int    $metric_id The metric_id to query
+ *
+ * @return array of table columns
  */
-function get_free_expression_table_columns($expression_id, $table, $type, $metric_id = 0) {
+function get_free_expression_table_columns(int $expression_id, string $table, string $type, int $metric_id = 0) : array {
 	if (!isset($table) || empty($table) || $table == '') {
 		return array();
 	}
@@ -2864,7 +3112,7 @@ function get_free_expression_table_columns($expression_id, $table, $type, $metri
 	return $table_columns;
 }
 
-function get_primary_key_from_table($table) {
+function get_primary_key_from_table(string $table) : array {
 	if (!isset($table) || empty($table) || $table == '') {
 		return array();
 	}
@@ -2883,14 +3131,19 @@ function get_primary_key_from_table($table) {
 	return $table_columns;
 }
 
-/*
-Replace last 'WHERE' part
-
-1. If case insensitive string patern 'WHERE+<any characters>+)+<any white spaces>+AS' is found, replace it with 'LIMIT 1) AS'
-2. Otherwise cut off the last 'WHERE' part
-*/
-function replace_where_from_sql($sql) {
+/**
+ * Replace last 'WHERE' part
+ *
+ * 1. If case insensitive string patern 'WHERE+<any characters>+)+<any white spaces>+AS' is found, replace it with 'LIMIT 1) AS'
+ * 2. Otherwise cut off the last 'WHERE' part
+ *
+ * @param  string The base sql query
+ *
+ * @return string The adjusted query
+ */
+function replace_where_from_sql(string $sql) : string {
 	$last_where_pos = strripos($sql, 'WHERE');
+
 	if (!$last_where_pos) {
 		return $sql;
 	}
@@ -2911,44 +3164,75 @@ function replace_where_from_sql($sql) {
 	return($sql1 . $sql2);
 }
 
-function get_columns_from_sql($sql, $type, $expression_id = 0) {
+function get_columns_from_sql(string $sql, string $type, int $expression_id = 0, bool $force = false) : array {
 	global $gl_clusterid, $gl_clustername;
 
-	$sql_columns = array();
-	$results     = array();
-
 	if ($type == 'alarm') {
-		$sql = gridalarms_replace_custom_input($expression_id, $sql);
-	} elseif ($type == 'template') {
-		$sql = gridalarms_template_replace_custom_input($expression_id, $sql);
-	}
-
-	$tmp_cluster = db_fetch_row('SELECT clusterid, clustername
-		FROM grid_clusters
-		LIMIT 1');
-
-	if (!empty($gl_clusterid)) {
-		$sql = str_replace('|alert_clusterid|', $gl_clusterid, $sql);
-		$sql = str_replace('|alert_clustername|', $gl_clustername, $sql);
+		$column_data = db_fetch_cell_prepared('SELECT column_data
+			FROM gridalarms_expression
+			WHERE id = ?',
+			array($expression_id));
 	} else {
-		if (!empty($tmp_cluster['clusterid'])) {
-			$sql = str_replace('|alert_clusterid|', $tmp_cluster['clusterid'], $sql);
-			$sql = str_replace('|alert_clustername|', $tmp_cluster['clustername'], $sql);
+		$column_data = db_fetch_cell_prepared('SELECT column_data
+			FROM gridalarms_template_expression
+			WHERE id = ?',
+			array($expression_id));
+	}
+
+	$sql_columns = array();
+	$column_data = trim($column_data);
+
+	if ($column_data != '' && !$force) {
+		$columns = json_decode($column_data, true);
+
+		if (cacti_sizeof($columns)) {
+			foreach($columns as $column) {
+				$sql_columns[$column] = $column;
+			}
 		}
 	}
 
-	if (strlen($sql)) {
-		$sql = replace_where_from_sql($sql);
-		$sql_columns_query = $sql . ' LIMIT 1';
-		$results = db_fetch_assoc($sql_columns_query);
-	}
+	if (!sizeof($sql_columns)) {
+		$results = array();
 
-	if (cacti_sizeof($results)) {
-		$columns = array_keys($results[0]);
-
-		foreach ($columns as $column) {
-			$sql_columns[$column] = $column;
+		if ($type == 'alarm') {
+			$sql = gridalarms_replace_custom_input($expression_id, $sql);
+		} elseif ($type == 'template') {
+			$sql = gridalarms_template_replace_custom_input($expression_id, $sql);
 		}
+
+		$tmp_cluster = db_fetch_row('SELECT clusterid, clustername
+			FROM grid_clusters
+			LIMIT 1');
+
+		if (!empty($gl_clusterid)) {
+			$sql = str_replace('|alert_clusterid|', $gl_clusterid, $sql);
+			$sql = str_replace('|alert_clustername|', $gl_clustername, $sql);
+		} else {
+			if (!empty($tmp_cluster['clusterid'])) {
+				$sql = str_replace('|alert_clusterid|', $tmp_cluster['clusterid'], $sql);
+				$sql = str_replace('|alert_clustername|', $tmp_cluster['clustername'], $sql);
+			}
+		}
+
+		if (strlen($sql)) {
+			$sql = replace_where_from_sql($sql);
+			$sql_columns_query = $sql . ' LIMIT 1';
+			$results = db_fetch_assoc($sql_columns_query);
+		}
+
+		if (cacti_sizeof($results)) {
+			$columns = array_keys($results[0]);
+
+			foreach ($columns as $column) {
+				$sql_columns[$column] = $column;
+			}
+		}
+
+		db_execute_prepared('UPDATE gridalarms_expression
+			SET column_data = ?
+			WHERE id = ?',
+			array(json_encode($sql_columns), $expression_id));
 	}
 
 	return $sql_columns;
@@ -2956,9 +3240,12 @@ function get_columns_from_sql($sql, $type, $expression_id = 0) {
 
 /**
  * Return the list of tables based on the type selected in the form.
- * @param String $type
+ *
+ * @param  string $type The class of tables to return
+ *
+ * @return array The tables by class
  */
-function get_db_tables_form($type) {
+function get_db_tables_form(string $type) : array {
 	global $metric_types, $license_tables, $cluster_tables, $host_tables, $queue_tables, $user_tables, $job_tables;
 
 	$db_tables = array();
@@ -2994,10 +3281,11 @@ function get_db_tables_form($type) {
 	return $db_tables;
 }
 
-function alarm_log_legend() {
+function alarm_log_legend() : void {
 	global $alarm_log_bgcolors;
 
     html_start_box('', '100%', '', '3', 'center', '');
+
     print '<tr>';
     print '<td class="gridalarmsAlertNotify">'     . __('Alert Notify', 'gridalarms')     . '</td>';
     print '<td class="gridalarmsReTriggerNotify">' . __('ReTrigger Notify', 'gridalarms') . '</td>';
@@ -3006,11 +3294,13 @@ function alarm_log_legend() {
     print '<td class="gridalarmsRestoralNotify">'  . __('Restoral Notify', 'gridalarms')  . '</td>';
     print '<td class="gridalarmsRestoralEvent">'   . __('Restoral Event', 'gridalarms')   . '</td>';
     print '</tr>';
+
     html_end_box(false);
 }
 
-function alarm_legend() {
+function alarm_legend() : void {
 	html_start_box('', '100%', '', '3', 'center', '');
+
 	print '<tr>';
 	print '<td class="gridalarmsAlert">'           . __('Alert', 'gridalarms')                    . '</td>';
 	print '<td class="gridalarmsAcknowledgementRequired">' . __('Acknowledgement Required', 'gridalarms') . '</td>';
@@ -3018,10 +3308,11 @@ function alarm_legend() {
 	print '<td class="gridalarmsOk">'              . __('Ok', 'gridalarms')                       . '</td>';
 	print '<td class="gridalarmsDisabled">'        . __('Disabled', 'gridalarms')                 . '</td>';
 	print '</tr>';
+
 	html_end_box(false);
 }
 
-function list_alarm_log_detail() {
+function list_alarm_log_detail() : void {
 	global $log_types, $log_types_display;
 
 	$logid = get_request_var('logid');
@@ -3036,44 +3327,52 @@ function list_alarm_log_detail() {
 
 	html_start_box(__('Alert Log Entry Details', 'gridalarms'), '100%', '', '3', 'center', '');
 
-	$i = 0;
 	if (cacti_sizeof($details)) {
 		form_alternate_row();
-		print "<td style='white-space:nowrap;width:10%;'><b>Name:</b></td><td>" . html_escape($alarm['name']) . "</td>\n";
+		print "<td style='white-space:nowrap;width:10%;'><b>Name:</b></td><td>" . html_escape($alarm['name']) . "</td>";
 		form_end_row();
 
 		form_alternate_row();
-		print "<td style='white-space:nowrap;width:10%;'><b>Alert Trigger Value:</b></td><td>" . html_escape($details['alarm_value']) . "</td>\n";
+		print "<td style='white-space:nowrap;width:10%;'><b>Alert Trigger Value:</b></td><td>" . html_escape($details['alarm_value']) . "</td>";
 		form_end_row();
 
 		form_alternate_row();
-		print "<td style='white-space:nowrap;width:10%;'><b>Measured Value:</b></td><td>" . html_escape($details['current']) . "</td>\n";
+		print "<td style='white-space:nowrap;width:10%;'><b>Measured Value:</b></td><td>" . html_escape($details['current']) . "</td>";
 		form_end_row();
 
 		form_alternate_row();
-		print "<td style='white-space:nowrap;width:10%;'><b>Log Time:</b></td><td>" . date("Y-m-d H:i:s", $details['time']) . "</td>\n";
+		print "<td style='white-space:nowrap;width:10%;'><b>Log Time:</b></td><td>" . date("Y-m-d H:i:s", $details['time']) . "</td>";
 		form_end_row();
 
 		form_alternate_row();
-		print "<td style='white-space:nowrap;width:10%;'><b>Status:</b></td><td>" . ucfirst($log_types_display[$details['status']]) . "</td>\n";
+		print "<td style='white-space:nowrap;width:10%;'><b>Status:</b></td><td>" . ucfirst($log_types_display[$details['status']]) . "</td>";
 		form_end_row();
 
 		form_alternate_row();
-		print "<td style='white-space:nowrap;width:10%;'><b>Log Message:</b></td><td>". html_escape($details['description']) . "</td>\n";
+		print "<td style='white-space:nowrap;width:10%;'><b>Log Message:</b></td><td>". html_escape($details['description']) . "</td>";
+		form_end_row();
+
+		form_alternate_row();
+		print "<td style='white-space:nowrap;width:10%;'><b>External ID:</b></td><td>" . html_escape($alarm['external_id']) . "</td>";
+		form_end_row();
+
+		form_alternate_row();
+		print "<td style='white-space:nowrap;width:10%;'><b>Operator Notes:</b></td><td>" . $alarm['notes'] . "</td>";
 		form_end_row();
 
 		html_end_box();
 
-		print base64url_decode($details['details']);
+		print rtm_base64url_decode($details['details']);
 	} else {
 		print '<tr><td>Unable to Find Log Record in Current Database!</td></tr>';
 		html_end_box(false);
 	}
 }
 
-function list_alarm_log($admin = true) {
+function list_alarm_log(bool $admin = true) : void {
 	global $alarm_bgcolors, $config, $gridalarms_platform_cols, $gridalarms_types,
 		$alarm_types, $log_types, $log_types_display, $alarm_log_bgcolors, $grid_rows_selector;
+
 	$sql_params = array();
 
 	alarm_log_request_validation();
@@ -3095,23 +3394,23 @@ function list_alarm_log($admin = true) {
 
 	$sql_where = '';
 	if (get_request_var('alarm_type') >= 0) {
-		$sql_where = 'WHERE ga.alarm_type=?';
+		$sql_where = 'WHERE ga.alarm_type = ?';
 		$sql_params[] = get_request_var('alarm_type');
 	}
 
 	if (get_request_var('id') > 0) {
-		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . 'alarm_id=?';
+		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . 'alarm_id = ?';
 		$sql_params[] = get_request_var('id');
 	}
 
 	if (get_request_var('status') != -1) {
-		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . 'status=?';
+		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . 'status = ?';
 		$sql_params[] = get_request_var('status');
 	}
 
 	if (get_request_var('filter') != '') {
-		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . "description LIKE ?";
-		$sql_params[] = '%'. get_request_var('filter') . '%';
+		$sql_where .= ($sql_where != '' ? ' AND ':'WHERE ') . 'description LIKE ?';
+		$sql_params[] = '%' . get_request_var('filter') . '%';
 	}
 
 	$sql_order = get_order_string();
@@ -3128,6 +3427,7 @@ function list_alarm_log($admin = true) {
 	$result = db_fetch_assoc_prepared($sql, $sql_params);
 
 	html_start_box(__('Alert Logs', 'gridalarms'), '100%', '', '3', 'center', '');
+
 	?>
 	<tr class='noprint even'>
 		<td>
@@ -3167,7 +3467,7 @@ function list_alarm_log($admin = true) {
 						<?php print __('Search', 'gridalarms');?>
 					</td>
 					<td>
-						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter');?>'>
+						<input type='text' id='filter' size='25' value='<?php print html_escape(get_request_var('filter'));?>'>
 					</td>
 					<td>
 						<?php print __('Alert', 'gridalarms');?>
@@ -3243,7 +3543,7 @@ function list_alarm_log($admin = true) {
 							<?php
 							if (cacti_sizeof($grid_rows_selector)) {
 								foreach ($grid_rows_selector as $key => $value) {
-									print '<option value="' . $key . '"'; if (get_request_var('rows') == $key) { print ' selected'; } print '>' . html_escape($value) . "</option>\n";
+									print '<option value="' . $key . '"'; if (get_request_var('rows') == $key) { print ' selected'; } print '>' . html_escape($value) . "</option>";
 								}
 							}
 							?>
@@ -3265,13 +3565,32 @@ function list_alarm_log($admin = true) {
 		$sql_where", $sql_params);
 
 	$display_text = array(
-		'name'        => array('display' => 'Name', 'sort' => 'ASC'),
-		'time'        => array('display' => 'Event Time', 'sort' => 'DESC'),
-		'alarm_value' => array('display' => 'Alert Value', 'sort' => 'ASC'),
-		'current'     => array('display' => 'Current Value', 'sort' => 'ASC'),
-		'status'      => array('display' => 'Status', 'sort' => 'ASC'),
-		'type'        => array('display' => 'Type', 'sort' => 'ASC'),
-		'description' => array('display' => 'Event Description', 'sort' => 'ASC')
+		'name' => array(
+			'display' => __('Name', 'gridalarms'),
+			'sort' => 'ASC'
+		),
+		'time' => array(
+			'display' => __('Event Time', 'gridalarms'),
+			'sort' => 'DESC'
+		),
+		'status' => array(
+			'display' => __('Status', 'gridalarms'),
+			'sort' => 'ASC'
+		),
+		'type' => array(
+			'display' => __('Type', 'gridalarms'),
+			'sort' => 'ASC'
+		),
+		'alarm_value' => array(
+			'display' => __('Alert Value', 'gridalarms'),
+			'align' => 'right',
+			'sort' => 'ASC'
+		),
+		'current' => array(
+			'display' => __('Current Value', 'gridalarms'),
+			'align' => 'right',
+			'sort' => 'ASC'
+		),
 	);
 
 	html_start_box('', '100%', '', '4', 'center', '');
@@ -3293,12 +3612,11 @@ function list_alarm_log($admin = true) {
 			$name = ($row['name'] != '' ? $row['name']:__('Alert Removed', 'gridalarms'));
 
 			$tmp_row_color = $alarm_log_bgcolors[$log_types[$row['status']]];
+
 			rtm_form_alternate_row_color($tmp_row_color, $tmp_row_color);
 
 			form_selectable_cell(filter_value($name, get_request_var('filter'), $url), $row['id'], '', '');
 			form_selectable_cell(date('Y-m-d H:i:s', $row['time']), $row['id'], '', '');
-			form_selectable_cell(html_escape($row['alarm_value']), $row['id'], '', '');
-			form_selectable_cell(html_escape($row['current']), $row['id'], '', '');
 			form_selectable_cell(ucfirst($log_types_display[$row['status']]), $row['id'], '', '');
 
 			if ($row['type'] == '99') {
@@ -3307,7 +3625,14 @@ function list_alarm_log($admin = true) {
 				form_selectable_cell($alarm_types[$row['type']], $row['id'], '', '');
 			}
 
-			form_selectable_cell(html_escape($row['description']), $row['id'], '', '');
+			if ($row['alarm_value'] == '') {
+				form_selectable_cell('-', $row['id'], '', 'right');
+			} else {
+				form_selectable_cell(html_escape($row['alarm_value']), $row['id'], '', 'right');
+			}
+
+			form_selectable_cell(html_escape($row['current']), $row['id'], '', 'right');
+
 			form_end_row();
 		}
 	} else {
@@ -3323,49 +3648,49 @@ function list_alarm_log($admin = true) {
 	alarm_log_legend();
 }
 
-function alarm_log_request_validation() {
+function alarm_log_request_validation() : void {
 	/* ================= input validation and session storage ================= */
 	$filters = array(
 		'rows' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
-			),
+		),
 		'page' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'default' => '1'
-			),
+		),
 		'filter' => array(
 			'filter' => FILTER_CALLBACK,
 			'pageset' => true,
 			'default' => '',
 			'options' => array('options' => 'sanitize_search_string')
-			),
+		),
 		'sort_column' => array(
 			'filter' => FILTER_CALLBACK,
-			'default' => 'description',
+			'default' => 'time',
 			'options' => array('options' => 'sanitize_search_string')
-			),
+		),
 		'sort_direction' => array(
 			'filter' => FILTER_CALLBACK,
-			'default' => 'ASC',
+			'default' => 'DESC',
 			'options' => array('options' => 'sanitize_search_string')
-			),
+		),
 		'alarm_type' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
-			),
+		),
 		'status' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
-			),
+		),
 		'id' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
-			)
+		)
 	);
 
 	validate_store_request_vars($filters, 'sess_galog');
@@ -3376,45 +3701,50 @@ function alarm_log_request_validation() {
  *  This is a generic funtion for this page that makes sure that
  *  we have a good request.  We want to protect against people who
  *  like to create issues with Cacti.
-*/
-function alarm_template_request_validation() {
+ */
+function alarm_template_request_validation() : void {
 	/* ================= input validation and session storage ================= */
 	$filters = array(
 		'rows' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
-			),
+		),
 		'page' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'default' => '1'
-			),
+		),
 		'filter' => array(
 			'filter' => FILTER_CALLBACK,
 			'pageset' => true,
 			'default' => '',
 			'options' => array('options' => 'sanitize_search_string')
-			),
+		),
 		'sort_column' => array(
 			'filter' => FILTER_CALLBACK,
 			'default' => 'name',
 			'options' => array('options' => 'sanitize_search_string')
-			),
+		),
 		'sort_direction' => array(
 			'filter' => FILTER_CALLBACK,
 			'default' => 'ASC',
 			'options' => array('options' => 'sanitize_search_string')
-			),
+		),
 		'alarm_type' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
-			),
+		),
+		'ds_type' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'pageset' => true,
+			'default' => '-1'
+		),
 		'clusterid' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '0'
-			)
+		)
 	);
 
 	validate_store_request_vars($filters, 'sess_gatp');
@@ -3425,62 +3755,67 @@ function alarm_template_request_validation() {
  *  This is a generic funtion for this page that makes sure that
  *  we have a good request.  We want to protect against people who
  *  like to create issues with Cacti.
-*/
-function alarm_request_validation() {
+ */
+function alarm_request_validation() : void {
 	/* ================= input validation and session storage ================= */
 	$filters = array(
 		'rows' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
-			),
+		),
 		'page' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'default' => '1'
-			),
+		),
 		'clusterid' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '0'
-			),
+		),
+		'template_id' => array(
+			'filter' => FILTER_VALIDATE_INT,
+			'pageset' => true,
+			'default' => '0'
+		),
 		'filter' => array(
 			'filter' => FILTER_CALLBACK,
 			'pageset' => true,
 			'default' => '',
 			'options' => array('options' => 'sanitize_search_string')
-			),
+		),
 		'sort_column' => array(
 			'filter' => FILTER_CALLBACK,
 			'default' => 'name',
 			'options' => array('options' => 'sanitize_search_string')
-			),
+		),
 		'sort_direction' => array(
 			'filter' => FILTER_CALLBACK,
 			'default' => 'ASC',
 			'options' => array('options' => 'sanitize_search_string')
-			),
+		),
 		'alarm_type' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
-			),
+		),
 		'alarm_ds_type' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'pageset' => true,
 			'default' => '-1'
-			),
+		),
 		'state' => array(
 			'filter' => FILTER_VALIDATE_INT,
 			'default' => 2,
 			'pageset' => true,
-			)
+		)
 	);
 
 	validate_store_request_vars($filters, 'sess_ga');
 	/* ================= input validation and session storage ================= */
 }
 
-function populate_template_default_layout(&$alarm) {
+function populate_template_default_layout(array &$alarm) : void {
 	$expression = get_template_expression_by_id($alarm['expression_id']);
 
 	if ($expression['ds_type'] == '0') {
@@ -3488,12 +3823,25 @@ function populate_template_default_layout(&$alarm) {
 
 		/* do the primary key first, and sort on it */
 		$i = 1;
+
 		if (cacti_sizeof($primary_key_array)) {
 			foreach ($primary_key_array as $metric) {
 				db_execute_prepared("REPLACE INTO gridalarms_template_layout
-					(alarm_id, hash, display_name, column_name, sequence, sortposition, sortdirection)
-					VALUES (?, ?, ?, ?, ?, ?, 0)",
-					array($alarm['id'], get_hash_alert_template(0, 'layout_item'), ucfirst($metric), $metric, $i, $i));
+					(alarm_id, hash, display_name, column_name, sequence, sortposition, sortdirection, type, align)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+					array(
+						$alarm['id'],
+						get_hash_alert_template(0, 'layout_item'),
+						ucfirst($metric),
+						$metric,
+						$i,
+						$i,
+						0,
+						'general',
+						'left'
+					)
+				);
+
 				$i++;
 			}
 		}
@@ -3519,31 +3867,59 @@ function populate_template_default_layout(&$alarm) {
 		if (cacti_sizeof($other_metrics2)) {
 			foreach ($other_metrics2 as $metric) {
 				db_execute_prepared("REPLACE INTO gridalarms_template_layout
-					(alarm_id, hash, display_name, column_name, sequence, sortposition, sortdirection)
-					VALUES (?, ?, ?, ?, ?, 0, 0)",
-					array($alarm['id'], get_hash_alert_template(0, 'layout_item'), ucfirst($metric), $metric, $i));
+					(alarm_id, hash, display_name, column_name, sequence, sortposition, sortdirection, type, align)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+					array(
+						$alarm['id'],
+						get_hash_alert_template(0, 'layout_item'),
+						ucfirst($metric),
+						$metric,
+						$i,
+						0,
+						0,
+						'general',
+						'left'
+					)
+				);
+
 				$i++;
 			}
 		}
 	} elseif ($expression['ds_type'] == '1') {
-		$columns = get_columns_from_sql($expression['sql_query'],"template",$alarm['expression_id']);
+		$columns = get_columns_from_sql($expression['sql_query'], 'template', $alarm['expression_id']);
 
 		/* populate this first 8 columns, leave the rest to the user */
 		$i = 1;
+
 		if (cacti_sizeof($columns)) {
 			foreach ($columns as $metric) {
 				db_execute_prepared("REPLACE INTO gridalarms_template_layout
-					(alarm_id, hash, display_name, column_name, sequence, sortposition, sortdirection)
-					VALUES (?, ?, ?, ?, ?, ?, 0)",
-					array($alarm['id'], get_hash_alert_template(0, 'layout_item'), ucfirst($metric), $metric, $i,  ($i < 4 ? $i:0)));
+					(alarm_id, hash, display_name, column_name, sequence, sortposition, sortdirection, type, align)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+					array(
+						$alarm['id'],
+						get_hash_alert_template(0, 'layout_item'),
+						ucfirst($metric),
+						$metric,
+						$i,
+						($i < 4 ? $i:0),
+						0,
+						'general',
+						'left'
+					)
+				);
+
 				$i++;
-				if ($i > 8) break;
+
+				if ($i > 8) {
+					break;
+				}
 			}
 		}
 	}
 }
 
-function populate_default_layout(&$alarm) {
+function populate_default_layout(array &$alarm) : void {
 	$expression = get_expression_by_id($alarm['expression_id']);
 
 	if ($expression['ds_type'] == '0') {
@@ -3551,12 +3927,24 @@ function populate_default_layout(&$alarm) {
 
 		/* do the primary key first, and sort on it */
 		$i = 1;
+
 		if (cacti_sizeof($primary_key_array)) {
 			foreach ($primary_key_array as $metric) {
-				db_execute_prepared("REPLACE INTO gridalarms_alarm_layout
-					(alarm_id, display_name, column_name, sequence, sortposition, sortdirection)
-					VALUES (?, ?, ?, ?, ?, 0)",
-					array($alarm['id'], ucfirst($metric), $metric, $i, $i));
+				db_execute_prepared('REPLACE INTO gridalarms_alarm_layout
+					(alarm_id, display_name, column_name, sequence, sortposition, sortdirection, type, align)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+					array(
+						$alarm['id'],
+						ucfirst($metric),
+						$metric,
+						$i,
+						$i,
+						0,
+						'general',
+						'left'
+					)
+				);
+
 				$i++;
 			}
 		}
@@ -3571,6 +3959,7 @@ function populate_default_layout(&$alarm) {
 		}
 
 		$other_metrics2 = array();
+
 		if (cacti_sizeof($other_metrics)) {
 			foreach ($other_metrics as $metric) {
 				if (($key_found = array_search($metric, $primary_key_array)) === false) {
@@ -3581,26 +3970,52 @@ function populate_default_layout(&$alarm) {
 
 		if (cacti_sizeof($other_metrics2)) {
 			foreach ($other_metrics2 as $metric) {
-				db_execute_prepared("REPLACE INTO gridalarms_alarm_layout
-					(alarm_id, display_name, column_name, sequence, sortposition, sortdirection)
-					VALUES (?, ?, ?, ?, 0, 0)",
-					array($alarm['id'], ucfirst($metric), $metric, $i));
+				db_execute_prepared('REPLACE INTO gridalarms_alarm_layout
+					(alarm_id, display_name, column_name, sequence, sortposition, sortdirection, type, align)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+					array(
+						$alarm['id'],
+						ucfirst($metric),
+						$metric,
+						$i,
+						0,
+						0,
+						'general',
+						'left'
+					)
+				);
+
 				$i++;
 			}
 		}
 	} elseif ($expression['ds_type'] == '1') {
-		$columns = get_columns_from_sql($expression['sql_query'],"alarm",$alarm['expression_id']);
+		$columns = get_columns_from_sql($expression['sql_query'], 'alarm', $alarm['expression_id']);
 
 		/* populate this first 8 columns, leave the rest to the user */
 		$i = 1;
+
 		if (cacti_sizeof($columns)) {
 			foreach ($columns as $metric) {
-				db_execute_prepared("REPLACE INTO gridalarms_alarm_layout
-					(alarm_id, display_name, column_name, sequence, sortposition, sortdirection)
-					VALUES (?, ?, ?, ?, ?, 0)",
-					array($alarm['id'], ucfirst($metric), $metric, $i, ($i < 4 ? $i:0)));
+				db_execute_prepared('REPLACE INTO gridalarms_alarm_layout
+					(alarm_id, display_name, column_name, sequence, sortposition, sortdirection, type, align)
+					VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+					array(
+						$alarm['id'],
+						ucfirst($metric),
+						$metric,
+						$i,
+						($i < 4 ? $i:0),
+						0,
+						'general',
+						'left'
+					)
+				);
+
 				$i++;
-				if ($i > 8) break;
+
+				if ($i > 8) {
+					break;
+				}
 			}
 		}
 	}
@@ -3609,7 +4024,7 @@ function populate_default_layout(&$alarm) {
 /**
  * alarm_breached_items - function returns the list of breached items for alarming
  */
-function alarm_breached_items($id, $return_details = false, $limits = true, $forenv = false, $istemplate = false) {
+function alarm_breached_items(int $id, bool $return_details = false, bool $limits = true, bool $forenv = false, bool $istemplate = false) : string {
 	global $config, $cnn_id;
 
 	/* ================= input validation ================= */
@@ -3630,34 +4045,83 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 
 	if (!$istemplate && $id > 0) {
 		$alarm = get_alarm_by_id($id);
+
 		if (cacti_sizeof($alarm)) {
 			$expression = get_expression_by_id($alarm['expression_id']);
 		}
 	} else {
-		$alarm      = get_template_by_id($id);
+		$alarm = get_template_by_id($id);
+
 		if (cacti_sizeof($alarm)) {
-			$expression = get_template_expression_by_id($alarm["expression_id"]);
+			$expression = get_template_expression_by_id($alarm['expression_id']);
 		}
 	}
 
-	if (cacti_sizeof($expression)) {
-	if ($expression['ds_type'] == 1 || $expression['ds_type'] == 0) {
+	if (!cacti_sizeof($expression)) {
+		// shorten the path, make readable for merge
+	} elseif ($expression['ds_type'] == 1 || $expression['ds_type'] == 0) {
 		if (!$istemplate) {
-			$nocolumns = db_fetch_cell_prepared('SELECT count(*) FROM  gridalarms_alarm_layout WHERE alarm_id=?', array($alarm['id']));
+			$nocolumns = db_fetch_cell_prepared('SELECT COUNT(*)
+				FROM gridalarms_alarm_layout
+				WHERE alarm_id = ?',
+				array($alarm['id']));
+
 			if (!$nocolumns) {
 				populate_default_layout($alarm);
 			}
-			$columns = db_fetch_assoc_prepared('SELECT * FROM gridalarms_alarm_layout WHERE alarm_id=? ORDER BY sequence ASC', array($alarm['id']));
-			$sorts   = db_fetch_assoc_prepared('SELECT * FROM gridalarms_alarm_layout WHERE alarm_id=? AND sortposition>0 ORDER BY sortposition ASC', array($alarm['id']));
-			$displays = array_rekey(db_fetch_assoc_prepared('SELECT * FROM gridalarms_alarm_layout WHERE alarm_id=? ORDER BY sequence ASC', array($alarm['id'])), 'column_name', 'display_name');
+
+			$columns = db_fetch_assoc_prepared('SELECT *
+				FROM gridalarms_alarm_layout
+				WHERE alarm_id = ?
+				ORDER BY sequence ASC',
+				array($alarm['id']));
+
+			$sorts = db_fetch_assoc_prepared('SELECT *
+				FROM gridalarms_alarm_layout
+				WHERE alarm_id = ?
+				AND sortposition > 0
+				ORDER BY sortposition ASC',
+				array($alarm['id']));
+
+			$displays = array_rekey(
+				db_fetch_assoc_prepared('SELECT *
+					FROM gridalarms_alarm_layout
+					WHERE alarm_id = ?
+					ORDER BY sequence ASC',
+					array($alarm['id'])),
+				'column_name', 'display_name'
+			);
 		} else {
-			$nocolumns = db_fetch_cell_prepared('SELECT count(*) FROM  gridalarms_template_layout WHERE alarm_id=?', array($alarm['id']));
+			$nocolumns = db_fetch_cell_prepared('SELECT COUNT(*)
+				FROM gridalarms_template_layout
+				WHERE alarm_id = ?',
+				array($alarm['id']));
+
 			if (!$nocolumns) {
 				populate_template_default_layout($alarm);
 			}
-			$columns = db_fetch_assoc_prepared('SELECT * FROM gridalarms_template_layout WHERE alarm_id=? ORDER BY sequence ASC', array($alarm['id']));
-			$sorts   = db_fetch_assoc_prepared('SELECT * FROM gridalarms_template_layout WHERE alarm_id=? AND sortposition>0 ORDER BY sortposition ASC', array($alarm['id']));
-			$displays = array_rekey(db_fetch_assoc_prepared('SELECT * FROM gridalarms_template_layout WHERE alarm_id=? ORDER BY sequence ASC', array($alarm['id'])), 'column_name', 'display_name');
+
+			$columns = db_fetch_assoc_prepared('SELECT *
+				FROM gridalarms_template_layout
+				WHERE alarm_id = ?
+				ORDER BY sequence ASC',
+				array($alarm['id']));
+
+			$sorts = db_fetch_assoc_prepared('SELECT *
+				FROM gridalarms_template_layout
+				WHERE alarm_id = ?
+				AND sortposition > 0
+				ORDER BY sortposition ASC',
+				array($alarm['id']));
+
+			$displays = array_rekey(
+				db_fetch_assoc_prepared('SELECT *
+					FROM gridalarms_template_layout
+					WHERE alarm_id = ?
+					ORDER BY sequence ASC',
+					array($alarm['id'])),
+				'column_name', 'display_name'
+			);
 		}
 
 		$display_text = array();
@@ -3671,7 +4135,13 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 		if (cacti_sizeof($columns)) {
 			foreach ($columns as $c) {
 				$column_names[$c['column_name']] = $c['column_name'];
-				$display_text['nosort' . $count] = array($displays[$c['column_name']], 'ASC');
+
+				$display_text['nosort' . $count] = array(
+					'display' => $displays[$c['column_name']],
+					'sort'    => 'ASC',
+					'align'   => ($c['align'] != '' ? $c['align']:'left')
+				);
+
 				$count++;
 
 				if ($c['column_name'] != 'clustername' || $expression['ds_type'] == 1) {
@@ -3718,6 +4188,7 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 			} else {
 				$sql_query = gridalarms_template_replace_custom_input($expression['id'], $expression['sql_query']);
 			}
+
 			$sql_query = do_script_variable_replacement($sql_query, $alarm);
 
 			if (!$limits) {
@@ -3728,6 +4199,7 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 		} else {
 			/* append clusterid to where clause if found in table primary keys */
 			$sql_from_where_extra = "";
+
 			if ($alarm['clusterid'] != 0 && ($clusterid)) {
 				$sql_from_where_extra = "clusterid=" . $alarm['clusterid'];
 			}
@@ -3756,81 +4228,182 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 					form_alternate_row();
 				}
 
-				foreach ($column_names as $c) {
+				foreach ($columns as $c) {
+					$class       = $c['align'] != '' ? $c['align']:'left';
+					$column_name = $c['column_name'];
+
+					// Many of these column names are string and general
+					// So we can ignore all but alignment for them.
 					if (!$forenv) {
-						switch(strtolower($c)) {
+						switch(strtolower($c['column_name'])) {
 						case 'clustername':
 							if (isset($item['clusterid'])) {
 								$cluster_name = get_clustername($item['clusterid']);
 								$cluster_name = !empty($cluster_name)? $cluster_name : __('N/A', 'gridalarms');
-								print "<td style='white-space:nowrap;'>" . html_escape($cluster_name) . "</td>\n";
+
+								print "<td class='$class nowrap'>" . html_escape($cluster_name) . "</td>";
 							} else {
-								print "<td style='white-space:nowrap;'>" . (isset($item[$c]) ? html_escape($item[$c]):'Not Found') . "</td>\n";
+								print "<td class='$class nowrap'" . (isset($item[$column_name]) ? html_escape($item[$column_name]):__('Not Found', 'gridalarms')) . "</td>";
 							}
+
 							break;
 						case 'jobid':
 							if (isset($column_names['indexid']) && isset($column_names['submit_time']) && isset($column_names['clusterid'])) {
 								$href_str = $httpurl . 'plugins/grid/grid_bjobs.php?query=1&action=viewjob&clusterid=' .  $item['clusterid'] . '&indexid=' . $item['indexid'] . '&jobid=' . $item['jobid'] . '&submit_time=' .  strtotime($item['submit_time']) . '&title='. $item['jobid'];
+
 								if (isset($item['start_time'])) {
 									$href_str .= (strtotime($item['start_time'])? '&start_time=' . strtotime($item['start_time']) : '');
 								}
+
 								if (isset($item['end_time'])) {
 									$href_str .= (strtotime($item['end_time'])? '&end_time=' . strtotime($item['end_time']) : '');
 								}
-								print "<td style='white-space:nowrap;'><a href='" . html_escape($href_str) . "'>" .
-									$item['jobid'] . "</a></td>\n";
+
+								print "<td class='$class nowrap'><a href='" . html_escape($href_str) . "'>" . $item['jobid'] . "</a></td>";
 							} else {
-								print "<td style='white-space:nowrap;'>" . (isset($item[$c]) ? html_escape($item[$c]):'Not Found') . "</td>";
+								print "<td class='$class nowrap'>" . (isset($item[$column_name]) ? html_escape($item[$column_name]):__('Not Found', 'gridalarms')) . "</td>";
 							}
+
 							break;
 						case 'queue':
 						case 'queuename':
 							if (isset($column_names['clusterid'])) {
-								if ('lost_and_found'== $item[$c]) {
-									print "<td style='white-space:nowrap;'><a class='pic'>" . html_escape($item[$c]) . "</a></td>\n";
+								if ('lost_and_found'== $item[$column_name]) {
+									print "<td class='$class nowrap'><a class='pic'>" . html_escape($item[$column_name]) . "</a></td>";
 								} else {
-									print "<td style='white-space:nowrap;'><a href='" . html_escape($httpurl . 'plugins/grid/grid_bqueues.php?query=1&action=&clusterid=' .
-									$item['clusterid'] . '&filter=' . $item[$c]) . "'>" .
-									html_escape($item[$c]) . "</a></td>\n";
+									print "<td class='$class nowrap'><a href='" . html_escape($httpurl . 'plugins/grid/grid_bqueues.php?query=1&action=&clusterid=' .
+									$item['clusterid'] . '&filter=' . $item[$column_name]) . "'>" .
+									html_escape($item[$column_name]) . "</a></td>";
 								}
 							} else {
-								print "<td style='white-space:nowrap;'>" . (isset($item[$c]) ? html_escape($item[$c]):'Not Found') . "</td>\n";
+								print "<td class='$class nowrap'>" . (isset($item[$column_name]) ? html_escape($item[$column_name]):__('Not Found', 'gridalarms')) . "</td>";
 							}
+
 							break;
 						case 'exec_host':
 						case 'from_host':
 						case 'host':
 							if (isset($item['clusterid'])) {
-								print "<td style='white-space:nowrap;'><a href='" . html_escape($httpurl . 'plugins/grid/grid_bzen.php?action=zoom&clusterid=' .
-									$item['clusterid'] . '&exec_host=' . $item[$c]) . "'>" .
-									html_escape($item[$c]) . "</a></td>\n";
+								print "<td class='$class nowrap'><a href='" . html_escape($httpurl . 'plugins/grid/grid_bzen.php?action=zoom&clusterid=' .
+									$item['clusterid'] . '&exec_host=' . $item[$column_name]) . "'>" .
+									html_escape($item[$column_name]) . "</a></td>";
 							} else {
-								print "<td style='white-space:nowrap;'>" . (isset($item[$c]) ? html_escape($item[$c]):'Not Found') . "</td>\n";
+								print "<td class='$class nowrap'>" . (isset($item[$column_name]) ? html_escape($item[$column_name]):__('Not Found', 'gridalarms')) . "</td>";
 							}
+
 							break;
 						case 'feature_name':
-							print "<td style='white-space:nowrap;'><a href='" . html_escape($httpurl . 'plugins/license/lic_checkouts.php?query=1&filter=' .
-								html_escape($item[$c])) . "'>" .
-								html_escape($item[$c]) . "</a></td>\n";
+							print "<td class='$class nowrap'><a href='" . html_escape($httpurl . 'plugins/license/lic_checkouts.php?query=1&filter=' .
+								html_escape($item[$column_name])) . "'>" .
+								html_escape($item[$column_name]) . "</a></td>";
+
 							break;
 						case 'user':
 						case 'username':
 							if (isset($item['clusterid'])) {
-								print "<td style='white-space:nowrap;'><a href='" . html_escape($httpurl . 'plugins/grid/grid_busers.php?query=1&noactivity=true&clusterid=' .
-									$item['clusterid'] . '&filter=' . $item[$c]) . "'>" .
-									html_escape($item[$c]) . "</a></td>\n";
+								print "<td class='$class nowrap'><a href='" . html_escape($httpurl . 'plugins/grid/grid_busers.php?query=1&noactivity=true&clusterid=' .
+									$item['clusterid'] . '&filter=' . $item[$column_name]) . "'>" .
+									html_escape($item[$column_name]) . "</a></td>";
 							} else {
-								print "<td style='white-space:nowrap;'>" . (isset($item[$c]) ? html_escape($item[$c]):'Not Found') . "</td>\n";
+								print "<td class='$class nowrap'>" . (isset($item[$column_name]) ? html_escape($item[$column_name]):__('Not Found', 'gridalarms')) . "</td>";
 							}
+
 							break;
 						default:
-							print "<td style='white-space:nowrap;'>" . (isset($item[$c]) ? html_escape($item[$c]):'Not Found') . "</td>\n";
+							if ($c['type'] == 'general' || $c['type'] == 'string' || $c['type'] == 'date') {
+								print "<td class='$class nowrap'>" . (isset($item[$column_name]) ? html_escape($item[$column_name]):__('Not Found', 'gridalarms')) . "</td>";
+							} elseif ($c['type'] == 'integer' || $c['type'] == 'double') {
+								if (!isset($item[$column_name])) {
+									print "<td class='$class nowrap'>" . __('Not Found', 'gridalarms') . '</td>';
+								} elseif (is_numeric($item[$column_name])) {
+									$suffix = '';
+									switch($c['units']) {
+										case 'bytes':
+											if ($c['autoscale'] == '-1' || $c['autoscale'] == '0') {
+												$value = display_job_memory($item[$column_name] / 1000, $c['digits']);
+											} else {
+												$value = number_format_i18n($item[$column_name], $c['digits']) . ' B';
+											}
+										case 'kbytes':
+											if ($c['autoscale'] == '-1' || $c['autoscale'] == '0') {
+												$value = display_job_memory($item[$column_name], $c['digits']);
+											} else {
+												$value = number_format_i18n($item[$column_name], $c['digits']) . ' KB';
+											}
+											break;
+										case 'mbytes':
+											if ($c['autoscale'] == '-1' || $c['autoscale'] == '0') {
+												$value = display_job_memory($item[$column_name] * 1000, $c['digits']);
+											} else {
+												$value = number_format_i18n($item[$column_name], $c['digits']) . ' MB';
+											}
+											break;
+										case 'gbytes':
+											if ($c['autoscale'] == '-1' || $c['autoscale'] == '0') {
+												$value = display_job_memory($item[$column_name] * 1000000, $c['digits']);
+											} else {
+												$value = number_format_i18n($item[$column_name], $c['digits']) . ' GB';
+											}
+											break;
+										case 'tbytes':
+											if ($c['autoscale'] == '-1' || $c['autoscale'] == '0') {
+												$value = display_job_memory($item[$column_name] * 1000000000, $c['digits']);
+											} else {
+												$value = number_format_i18n($item[$column_name], $c['digits']) . ' TB';
+											}
+											break;
+										case 'pbytes':
+											if ($c['autoscale'] == '-1' || $c['autoscale'] == '0') {
+												$value = display_job_memory($item[$column_name] * 1000000000000, $c['digits']);
+											} else {
+												$value = number_format_i18n($item[$column_name], $c['digits']) . ' PB';
+											}
+											break;
+										case 'xbytes':
+											if ($c['autoscale'] == '-1' || $c['autoscale'] == '0') {
+												$value = display_job_memory($item[$column_name] * 1000000000000000, $c['digits']);
+											} else {
+												$value = number_format_i18n($item[$column_name], $c['digits']) . ' EB';
+											}
+											break;
+										case 'jobs':
+											$value = $item[$column_name];
+											$suffix = ' Jobs';
+											break;
+										case 'slots':
+											$value = $item[$column_name];
+											$suffix = ' Slots';
+											break;
+										case 'seconds':
+											$value = display_job_time($item[$column_name] * 60, $c['digits'], false);
+											break;
+										case 'minutes':
+											$value = display_job_time($item[$column_name] * 60, $c['digits'], false);
+											break;
+										case 'hours':
+											$value = display_job_time($item[$column_name] * 3600, $c['digits'], false);
+											break;
+										case 'days':
+											$value = display_job_time($item[$column_name] * 86400, $c['digits'], false);
+											break;
+										default:
+											$value = $item[$column_name];
+											break;
+									}
+
+									print "<td class='$class nowrap'>" . html_escape($value . $suffix) . "</td>";
+								} else {
+									print "<td class='$class nowrap'>" . html_escape($item[$column_name]) . '</td>';
+								}
+							} elseif ($c['type'] == 'fpercent') {
+							} elseif ($c['type'] == 'wpercent') {
+							}
 						}
 					} else {
 						if ($c == 'clustername' && $expression['ds_type'] == 0) {
 							$line .= (strlen($line) ? ',':'') . (html_escape(get_clustername($item['clusterid'])));
 						} else {
-							$line .= (strlen($line) ? ',':'') . (isset($item[$c]) ? html_escape($item[$c]):'Not Found');
+							$line .= (strlen($line) ? ',':'') . (isset($item[$column_name]) ? html_escape($item[$column_name]):__('Not Found', 'gridalarms'));
 						}
 					}
 				}
@@ -3844,9 +4417,13 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 
 			/* storing items into the log_items table */
 			if ($return_details) {
-				$sql_insert = "INSERT INTO gridalarms_alarm_log_items ";
+				$sql_insert = 'INSERT INTO gridalarms_alarm_log_items ';
 
-				db_execute_prepared("UPDATE gridalarms_alarm_log_items SET present=0 WHERE alarm_id=? AND present=1", array($id));
+				db_execute_prepared('UPDATE gridalarms_alarm_log_items
+					SET present = 0
+					WHERE alarm_id = ?
+					AND present = 1',
+					array($id));
 
 				$j=0;
 
@@ -3867,71 +4444,90 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 						}
 
 						switch(strtolower($c)) {
-						case 'clustername': // Type 16
-							$ltype = $ltype | 16;
-							if (isset($item['clusterid'])) {
-								$sql .= (strlen($sql) ? ',':'') . db_qstr(get_clustername($item['clusterid']));
-								$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr(get_clustername($item['clusterid']));
-							} else {
-								$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$c]) ? $item[$c]:'Not Found');
-								if (isset($item[$c])) {
-									$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$c]);
+							case 'clustername': // Type 16
+								$ltype = $ltype | 16;
+
+								if (isset($item['clusterid'])) {
+									$sql .= (strlen($sql) ? ',':'') . db_qstr(get_clustername($item['clusterid']));
+									$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr(get_clustername($item['clusterid']));
+								} else {
+									$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$column_name]) ? $item[$column_name]:__('Not Found', 'gridalarms'));
+
+									if (isset($item[$column_name])) {
+										$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$column_name]);
+									}
 								}
-							}
-							break;
-						case 'jobid': // Type 1
-							if (isset($column_names['indexid']) && isset($column_names['submit_time']) && isset($column_names['clusterid'])) {
-								$ltype = $ltype | 1;
-							}
-							if (isset($item[$c])) {
-								$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$c]);
-							}
-							$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$c]) ? $item[$c]:'Not Found');
-							break;
-						case 'queue': // Type 4
-						case 'queuename':
-							if (isset($column_names['clusterid'])) {
-								$ltype = $ltype | 4;
-							}
-							if (isset($item[$c])) {
-								$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$c]);
-							}
-							$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$c]) ? $item[$c]:'Not Found');
-							break;
-						case 'exec_host': // Type 2
-						case 'from_host':
-						case 'host':
-						case 'hostname':
-							if (isset($item['clusterid'])) {
-								$ltype = $ltype | 2;
-							}
-							if (isset($item[$c])) {
-								$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$c]);
-							}
-							$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$c]) ? $item[$c]:'Not Found');
-							break;
-						case 'feature_name':
-							$ltype = $ltype | 32;
-							if (isset($item[$c])) {
-								$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$c]);
-							}
-							$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$c]) ? $item[$c]:'Not Found');
-							break;
-						case 'user':
-						case 'username':
-							if (isset($item['clusterid'])) {
-								$ltype = $ltype | 8;
-							}
-							if (isset($item[$c])) {
-								$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$c]);
-							}
-							$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$c]) ? $item[$c]:'Not Found');
-							break;
-						default:
-							if (isset($item[$c])) {
-								$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$c]);
-							}
-							$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$c]) ? $item[$c]:'Not Found');
+
+								break;
+							case 'jobid': // Type 1
+								if (isset($column_names['indexid']) && isset($column_names['submit_time']) && isset($column_names['clusterid'])) {
+									$ltype = $ltype | 1;
+								}
+
+								if (isset($item[$column_name])) {
+									$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$column_name]);
+								}
+
+								$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$column_name]) ? $item[$column_name]:__('Not Found', 'gridalarms'));
+
+								break;
+							case 'queue': // Type 4
+							case 'queuename':
+								if (isset($column_names['clusterid'])) {
+									$ltype = $ltype | 4;
+								}
+
+								if (isset($item[$column_name])) {
+									$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$column_name]);
+								}
+
+								$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$column_name]) ? $item[$column_name]:__('Not Found', 'gridalarms'));
+
+								break;
+							case 'exec_host': // Type 2
+							case 'from_host':
+							case 'host':
+							case 'hostname':
+								if (isset($item['clusterid'])) {
+									$ltype = $ltype | 2;
+								}
+
+								if (isset($item[$column_name])) {
+									$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$column_name]);
+								}
+
+								$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$column_name]) ? $item[$column_name]:__('Not Found', 'gridalarms'));
+
+								break;
+							case 'feature_name':
+								$ltype = $ltype | 32;
+
+								if (isset($item[$column_name])) {
+									$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$column_name]);
+								}
+
+								$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$column_name]) ? $item[$column_name]:__('Not Found', 'gridalarms'));
+
+								break;
+							case 'user':
+							case 'username':
+								if (isset($item['clusterid'])) {
+									$ltype = $ltype | 8;
+								}
+
+								if (isset($item[$column_name])) {
+									$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$column_name]);
+								}
+
+								$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$column_name]) ? $item[$column_name]:__('Not Found', 'gridalarms'));
+
+								break;
+							default:
+								if (isset($item[$column_name])) {
+									$csql .= (strlen($csql) ? ' AND ':'') . 'column' . substr('00' . $i, -2) . '=' . db_qstr($item[$column_name]);
+								}
+
+								$sql .= (strlen($sql) ? ',':'') . db_qstr(isset($item[$column_name]) ? $item[$column_name]:__('Not Found', 'gridalarms'));
 						}
 
 						$i++;
@@ -3947,20 +4543,34 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 						$ltype = 64;
 					}
 
-					$clusterid = 0;
-					$jobid = 0;
-					$indexid = 0;
-					$submit_time = '';
-					$queue = '';
-					$host = '';
+					$clusterid    = 0;
+					$jobid        = 0;
+					$indexid      = 0;
+					$submit_time  = '';
+					$queue        = '';
+					$host         = '';
 					$feature_name = '';
-					$user = '';
+					$user         = '';
 
-					if (isset($item['clusterid'])) $clusterid = $item['clusterid'];
-					if (isset($item['jobid'])) $jobid = $item['jobid'];
-					if (isset($item['indexid'])) $indexid = $item['indexid'];
-					if (isset($item['submit_time'])) $submit_time = $item['submit_time'];
-					if (isset($item['feature_name'])) $feature_name = $item['feature_name'];
+					if (isset($item['clusterid'])) {
+						$clusterid = $item['clusterid'];
+					}
+
+					if (isset($item['jobid'])) {
+						$jobid = $item['jobid'];
+					}
+
+					if (isset($item['indexid'])) {
+						$indexid = $item['indexid'];
+					}
+
+					if (isset($item['submit_time'])) {
+						$submit_time = $item['submit_time'];
+					}
+
+					if (isset($item['feature_name'])) {
+						$feature_name = $item['feature_name'];
+					}
 
 					if (isset($item['queue'])) {
 						$queue = $item['queue'];
@@ -3984,33 +4594,44 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 						$host = $item['from_host'];
 					}
 
-					$sql_array[$j]['sql'] = '(' . $id . "," . $ltype . "," . $clusterid . "," . $jobid . "," . $indexid . ",'" . $submit_time . "','"
-											. $queue . "','" . $host . "','" . $feature_name . "','" . $user . "'," . $sql . ",1, NOW())";
+					$sql_array[$j]['sql'] = '(' . $id . ',' . $ltype . ',' . $clusterid . ',' . $jobid . ',' . $indexid . ',' . db_qstr($submit_time) . ','
+						. db_qstr($queue) . ',' . db_qstr($host) . ',' . db_qstr($feature_name) . ',' . db_qstr($user) . ',' . $sql . ', 1, NOW())';
 
 					$sql_array[$j]['csql'] = "(alarm_id=$id AND clusterid=$clusterid AND host='$host' AND $csql)";
 					$j++;
 				}
 
 				if (cacti_sizeof($sql_array)) {
-				foreach ($sql_array as $a) {
-					$exists = db_fetch_cell("SELECT id FROM gridalarms_alarm_log_items WHERE " . $a['csql'], '', false);
-					if (!$exists) {
-						db_execute($sql_insert . $values . $a['sql']);
-					} else {
-						db_execute_prepared("UPDATE gridalarms_alarm_log_items SET last_updated=NOW(), present=1 WHERE id=?", array($exists));
+					foreach ($sql_array as $a) {
+						$exists = db_fetch_cell("SELECT id
+							FROM gridalarms_alarm_log_items
+							WHERE " . $a['csql'], '', false);
+
+						if (!$exists) {
+							db_execute($sql_insert . $values . $a['sql']);
+						} else {
+							db_execute_prepared('UPDATE gridalarms_alarm_log_items
+								SET last_updated = NOW(), present = 1
+								WHERE id = ?',
+								array($exists));
+						}
 					}
 				}
-				}
 
-				db_execute_prepared("DELETE FROM gridalarms_alarm_log_items WHERE alarm_id=? AND present=0", array($id));
+				db_execute_prepared('DELETE FROM gridalarms_alarm_log_items
+					WHERE alarm_id = ?
+					AND present = 0',
+					array($id));
 			}
 		} else {
 			if (!$forenv) {
-				print "<tr><td colspan='" . cacti_sizeof($column_names) . "'><em>No Threshold Breaching Items</em></td></tr>";
+				print "<tr><td colspan='" . cacti_sizeof($column_names) . "'><em>" . __('No Breached Items Found', 'gridalarms') . '</em></td></tr>';
 			}
 
 			if ($return_details) {
-				db_execute_prepared("DELETE FROM gridalarms_alarm_log_items WHERE alarm_id=?", array($id));
+				db_execute_prepared('DELETE FROM gridalarms_alarm_log_items
+					WHERE alarm_id = ?',
+					array($id));
 			}
 		}
 
@@ -4023,6 +4644,7 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 		} else {
 			$script_data = gridalarms_template_replace_custom_input($expression['id'], $expression['script_data']);
 		}
+
 		$script_data = do_script_variable_replacement($script_data, $alarm);
 		$script_data = "(" . str_replace("\r", "", str_replace("\n", "", $script_data)) . ")";
 
@@ -4105,16 +4727,17 @@ function alarm_breached_items($id, $return_details = false, $limits = true, $for
 			html_end_box(false);
 		}
 	}
-	}
 
 	if ($return_details && !$forenv) {
 		return ob_get_clean();
 	} elseif ($forenv) {
 		return $env;
+	} else {
+		return '';
 	}
 }
 
-function my_str_getcsv($input, $delimiter = ',', $enclosure = '"', $escape = '\\', $eol = '\n') {
+function my_str_getcsv(string $input, string $delimiter = ',', string $enclosure = '"', string $escape = '\\', string $eol = '\n') : bool|string {
 	if (is_string($input) && !empty($input)) {
 		$output = array();
 		$tmp    = preg_split("/".$eol."/", $input);
@@ -4165,7 +4788,7 @@ function my_str_getcsv($input, $delimiter = ',', $enclosure = '"', $escape = '\\
 	}
 }
 
-function alarm_tabs($admin = true) {
+function alarm_tabs(bool $admin = true) : void {
 	global $config;
 
 	get_filter_request_var('id');
@@ -4211,62 +4834,62 @@ function alarm_tabs($admin = true) {
 	print '</ul></nav></div>';
 }
 
-function alarm_enabled($id) {
+function alarm_enabled(int $alarm_id) : bool|int {
 	return db_fetch_cell_prepared('SELECT
 		IF(alarm_enabled="on",1,0)
 		FROM gridalarms_alarm WHERE id = ?',
-		array($id));
+		array($alarm_id));
 }
 
-function alarm_acknowledge_enabled($id) {
+function alarm_acknowledge_enabled(int $alarm_id) : bool|int {
 	return db_fetch_cell_prepared('SELECT
 		IF(req_ack="on",1,0)
 		FROM gridalarms_alarm WHERE id = ?',
-		array($id));
+		array($alarm_id));
 }
 
-function alarm_breached($id) {
+function alarm_breached(int $alarm_id) : bool|int {
 	return db_fetch_cell_prepared('SELECT IF(alarm_alert>1,1,0)
 		FROM gridalarms_alarm
 		WHERE id = ?',
-		array($id));
+		array($alarm_id));
 }
 
-function alarm_acknowledge_required($id) {
+function alarm_acknowledge_required(int $alarm_id) : bool|int {
 	return db_fetch_cell_prepared('SELECT IF(acknowledgement="on",1,0)
 		FROM gridalarms_alarm
 		WHERE id = ?',
-		array($id));
+		array($alarm_id));
 }
 
-function alarm_disable_prepared($id) {
+function alarm_disable_prepared(int $alarm_id) : bool|int {
 	db_execute_prepared('UPDATE gridalarms_alarm
 		SET alarm_enabled="off"
 		WHERE id = ?',
-		array($id));
+		array($alarm_id));
 }
 
-function alarm_enable_prepared($id) {
+function alarm_enable_prepared(int $alarm_id) : bool|int {
 	db_execute_prepared('UPDATE gridalarms_alarm
 		SET alarm_enabled="on"
 		WHERE id = ?',
-		array($id));
+		array($alarm_id));
 }
 
-function alarm_acknowledge($id) {
+function alarm_acknowledge(int $alarm_id) : bool|int{
 	db_execute_prepared('UPDATE gridalarms_alarm
 		SET acknowledgement="" WHERE id = ?',
-		array($id));
+		array($alarm_id));
 }
 
-function alarm_reset($id) {
+function alarm_reset(int $alarm_id) : bool|int {
 	db_execute_prepared('UPDATE gridalarms_alarm
 		SET acknowledgement="on"
 		WHERE id = ?',
-		array($id));
+		array($alarm_id));
 }
 
-function list_templates($admin = true) {
+function list_templates(bool $admin = true) {
 	global $alarm_bgcolors, $config, $template_actions, $alarm_types,
 		$frequencies, $grid_rows_selector, $gridalarms_types, $gridalarms_severities;
 
@@ -4290,7 +4913,7 @@ function list_templates($admin = true) {
 
 		// check gridalarms template xml
 		$dup_alarm_array = array();
-		$ret= check_import_xml_gridalarms_template($xml_data, $dup_alarm_array);
+		$ret = check_import_xml_gridalarms_template($xml_data, $dup_alarm_array);
 
 		if ($ret < 0) {                                   //show error message
 			raise_message(40, __("Invalid file."), MESSAGE_LEVEL_ERROR);
@@ -4336,7 +4959,6 @@ function list_templates($admin = true) {
 
 			exit;
 		}
-
 	} elseif (isset_request_var('import')) {  //display import page
 		top_header();
 
@@ -4366,6 +4988,7 @@ function list_templates($admin = true) {
 		form_end(false);
 
 		bottom_footer();
+
 		exit;
 	}
 
@@ -4373,21 +4996,26 @@ function list_templates($admin = true) {
 
 	$statefilter = '';
 	$sql_where   = '';
-	$sql_params = array();
+	$sql_params  = array();
 
 	if (isset_request_var('alarm_type') && get_request_var('alarm_type') != '-1') {
-		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_template.alarm_type=?';
+		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gat.alarm_type = ?';
 		$sql_params[] = get_request_var('alarm_type');
 	}
 
 	if (isset_request_var('clusterid') && get_request_var('clusterid') != '0') {
-		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_template.clusterid=?';
+		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gat.clusterid = ?';
 		$sql_params[] = get_request_var('clusterid');
 	}
 
+	if (isset_request_var('ds_type') && get_request_var('ds_type') >= 0) {
+		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gate.ds_type = ?';
+		$sql_params[] = get_request_var('ds_type');
+	}
+
 	if (isset_request_var('filter') && get_request_var('filter') != '') {
-		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_template.name LIKE ?';
-		$sql_params[] = '%'. get_request_var('filter') . '%';
+		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gat.name LIKE ?';
+		$sql_params[] = '%' . get_request_var('filter') . '%';
 	}
 
 	if (get_request_var('rows') <= 0) {
@@ -4399,19 +5027,18 @@ function list_templates($admin = true) {
 	$sql_order = get_order_string();
 	$sql_limit = ' LIMIT ' . ($rows*(get_request_var('page')-1)) . ",$rows";
 
-	$sql = "SELECT gridalarms_template.*, gridalarms_template_expression.ds_type
-		FROM gridalarms_template
-		LEFT JOIN gridalarms_template_expression
-		ON gridalarms_template.expression_id=gridalarms_template_expression.id
+	$sql = "SELECT gat.*, gate.ds_type, SUM(IF(ga.id IS NOT NULL,1,0)) AS alerts
+		FROM gridalarms_template AS gat
+		LEFT JOIN gridalarms_alarm AS ga
+		ON ga.template_id = gat.id
+		LEFT JOIN gridalarms_template_expression AS gate
+		ON gat.expression_id = gate.id
 		$sql_where
+		GROUP BY gat.id
 		$sql_order
 		$sql_limit";
 
 	$result = db_fetch_assoc_prepared($sql, $sql_params);
-
-	?>
-
-	<?php
 
 	html_start_box(__('Alert Template Management', 'gridalarms') . rtm_hover_help('rtm_alert_templates.html', __esc('Learn More', 'gridalarms')), '100%', '', '3', 'center', 'gridalarms_template_edit.php?tab=general&id=');
 
@@ -4421,12 +5048,6 @@ function list_templates($admin = true) {
 		<form id='listalarm' action='gridalarms_templates.php' method='get'>
 			<table class='filterTable'>
 				<tr>
-					<td>
-						<?php print __('Search', 'gridalarms');?>
-					</td>
-					<td>
-						<input type='text' size='25' id='filter' value='<?php print html_escape_request_var('filter');?>'>
-					</td>
 					<td>
 						<?php print __('Cluster', 'gridalarms');?>
 					</td>
@@ -4449,7 +5070,18 @@ function list_templates($admin = true) {
 						</select>
 					</td>
 					<td>
-						<?php print __('Type', 'gridalarms');?>
+						<?php print __('Data Type', 'gridalarms');?>
+					</td>
+					<td>
+						<select id='ds_type' onChange='applyFilter()'>
+							<option value='-1' <?php if (!isset_request_var('ds_type') || get_request_var('ds_type') == '-1') print "selected";?>>All</option>
+							<option value='0' <?php if (get_request_var('ds_type') == '0') print "selected";?>>Table</option>
+							<option value='1' <?php if (get_request_var('ds_type') == '1') print "selected";?>>SQL Query</option>
+							<option value='2' <?php if (get_request_var('ds_type') == '2') print "selected";?>>Script</option>
+						</select>
+					</td>
+					<td>
+						<?php print __('Threshold Type', 'gridalarms');?>
 					</td>
 					<td>
 						<select id='alarm_type' onChange='applyFilter()'>
@@ -4457,6 +5089,27 @@ function list_templates($admin = true) {
 							<option value='0' <?php if (get_request_var('alarm_type') == '0') print "selected";?>>Hi/Low</option>
 							<option value='1' <?php if (get_request_var('alarm_type') == '1') print "selected";?>>Time-Based</option>
 						</select>
+					</td>
+					<td>
+						<span>
+							<input type='button' id='go' value='<?php print __('Go', 'gridalarms');?>' title='<?php print __('Search for Alert', 'gridalarms');?>'>
+							<input type='button' id='clear' value='<?php print __('Clear', 'gridalarms');?>' title='<?php print __('Clear Filters', 'gridalarms');?>'>
+							<input type='button' id='import' value='<?php print __('Import', 'gridalarms');?>' title='<?php print __('Import Templates', 'gridalarms');?>'>
+						</span>
+					</td>
+					<td>
+						<input type='hidden' id='tab' value='alarms'>
+						<input type='hidden' id='search' value='search'>
+					</td>
+				</tr>
+			</table>
+			<table class='filterTable'>
+				<tr>
+					<td>
+						<?php print __('Search', 'gridalarms');?>
+					</td>
+					<td>
+						<input type='text' size='25' id='filter' value='<?php print html_escape(get_request_var('filter'));?>'>
 					</td>
 					<td>
 						<?php print __('Alerts', 'gridalarms');?>
@@ -4472,19 +5125,6 @@ function list_templates($admin = true) {
 						?>
 						</select>
 					</td>
-					<td>
-						<input type='button' id='go' value='<?php print __('Go', 'gridalarms');?>' title='<?php print __('Search for Alert', 'gridalarms');?>'>
-					</td>
-					<td>
-						<input type='button' id='clear' value='<?php print __('Clear', 'gridalarms');?>' title='<?php print __('Clear Filters', 'gridalarms');?>'>
-					</td>
-					<td>
-						<input type='button' id='import' value='<?php print __('Import', 'gridalarms');?>' title='<?php print __('Import Templates', 'gridalarms');?>'>
-					</td>
-					<td>
-						<input type='hidden' id='tab' value='alarms'>
-						<input type='hidden' id='search' value='search'>
-					</td>
 				</tr>
 			</table>
 		</form>
@@ -4492,9 +5132,10 @@ function list_templates($admin = true) {
 		function applyFilter() {
 			strURL  = 'gridalarms_templates.php?tab=alarms&header=false';
 			strURL += '&alarm_type=' + $('#alarm_type').val();
-			strURL += '&rows=' + $('#rows').val();
-			strURL += '&clusterid=' + $('#clusterid').val();
-			strURL += '&filter=' + $('#filter').val();
+			strURL += '&rows='       + $('#rows').val();
+			strURL += '&ds_type='    + $('#ds_type').val();
+			strURL += '&clusterid='  + $('#clusterid').val();
+			strURL += '&filter='     + $('#filter').val();
 			loadPageNoHeader(strURL);
 		}
 
@@ -4530,22 +5171,82 @@ function list_templates($admin = true) {
 
 	html_end_box();
 
-	$total_rows = db_fetch_cell_prepared("SELECT count(*)
-		FROM gridalarms_template
+	$total_rows = db_fetch_cell_prepared("SELECT COUNT(*)
+		FROM gridalarms_template AS gat
+		LEFT JOIN gridalarms_alarm AS ga
+		ON ga.template_id = gat.id
+		LEFT JOIN gridalarms_template_expression AS gate
+		ON gat.expression_id = gate.id
 		$sql_where", $sql_params);
 
 	$display_text = array(
-		'name'               => array('display' => __('Name', 'gridalarms'),         'sort' => 'ASC'),
-		'nosort1'            => array('display' => __('Cluster', 'gridalarms'),      'sort' => 'ASC'),
-		'syslog_priority'    => array('display' => __('Severity', 'gridalarms'),     'sort' => 'ASC'),
-		'nosort2'            => array('display' => __('Alert Type', 'gridalarms'),   'sort' => 'ASC'),
-		'frequency'          => array('display' => __('Check Freq', 'gridalarms'),   'sort' => 'ASC'),
-		'alarm_type'         => array('display' => __('Value Type', 'gridalarms'),   'sort' => 'ASC'),
-		'alarm_hi'           => array('display' => __('High', 'gridalarms'),         'sort' => 'ASC', 'align' => 'right'),
-		'alarm_low'          => array('display' => __('Low', 'gridalarms'),          'sort' => 'ASC', 'align' => 'right'),
-		'alarm_fail_trigger' => array('display' => __('Trigger', 'gridalarms'),      'sort' => 'ASC'),
-		'time_fail_length'   => array('display' => __('Duration', 'gridalarms'),     'sort' => 'ASC'),
-		'repeat_alert'       => array('display' => __('Repeat Alert', 'gridalarms'), 'sort' => 'ASC')
+		'name' => array(
+			'display' => __('Name', 'gridalarms'),
+			'sort' => 'ASC'
+		),
+		'external_id' => array(
+			'display' => __('External ID', 'gridalarms'),
+			'sort' => 'ASC'
+		),
+		'nosort1' => array(
+			'display' => __('Template Cluster', 'gridalarms'),
+			'sort' => 'ASC'
+		),
+		'id' => array(
+			'display' => __('ID', 'gridalarms'),
+			'sort'    => 'ASC',
+			'align' => 'right'
+		),
+		'alerts' => array(
+			'display' => __('Alerts', 'gridalarms'),
+			'sort'    => 'DESC',
+			'align' => 'right'
+		),
+		'syslog_priority' => array(
+			'display' => __('Severity', 'gridalarms'),
+			'sort' => 'ASC',
+			'align' => 'right'
+		),
+		'nosort2' => array(
+			'display' => __('Alert Type', 'gridalarms'),
+			'sort' => 'ASC',
+			'align' => 'right'
+		),
+		'frequency' => array(
+			'display' => __('Check Freq', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'alarm_type' => array(
+			'display' => __('Value Type', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'alarm_hi' => array(
+			'display' => __('High', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'alarm_low' => array(
+			'display' => __('Low', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'alarm_fail_trigger' => array(
+			'display' => __('Trigger', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'time_fail_length' => array(
+			'display' => __('Duration', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'repeat_alert' => array(
+			'display' => __('Repeat Alert', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		)
 	);
 
 	$nav = html_nav_bar('gridalarms_templates.php', MAX_DISPLAY_PAGES, get_request_var('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Alert Templates'), 'page', 'main');
@@ -4577,6 +5278,10 @@ function list_templates($admin = true) {
 			form_alternate_row('line' . $row['id'], false);
 			form_selectable_cell(filter_value($name, get_request_var('filter'), 'gridalarms_template_edit.php?tab=general&id=' . $row['id']), $row['id'], '', '');
 
+			form_selectable_cell($row['external_id'], $row['id']);
+
+			$url = $config['url_path'] . 'plugins/gridalarms/gridalarms_alarm.php?template_id=' . $row['id'];
+
 			if ($row['clusterid'] == '0') {
 				form_selectable_cell(__('N/A', 'gridalarms'), $row['id'], '', '');
 			} else {
@@ -4585,21 +5290,24 @@ function list_templates($admin = true) {
 				form_selectable_cell($cluster_name, $row['id'], '', '');
 			}
 
-			form_selectable_cell($gridalarms_severities[$row['syslog_priority']], $row['id'], '', '');
-			form_selectable_cell($row['ds_type'] != '' ? $gridalarms_types[$row['ds_type']] : __('Not Defined', 'gridalarms'), $row['id'], '', '');
-			form_selectable_cell($frequencies[$row['frequency']], $row['id'], '', '');
-			form_selectable_cell($alarm_types[$row['alarm_type']], $row['id'], '', '');
+			form_selectable_cell($row['id'], $row['id'], '', 'right');
+			form_selectable_cell(filter_value($row['alerts'], '', $url), $row['id'], '', 'right');
+
+			form_selectable_cell($gridalarms_severities[$row['syslog_priority']], $row['id'], '', 'right');
+			form_selectable_cell($row['ds_type'] != '' ? $gridalarms_types[$row['ds_type']] : __('Not Defined', 'gridalarms'), $row['id'], '', 'right');
+			form_selectable_cell($frequencies[$row['frequency']], $row['id'], '', 'right');
+			form_selectable_cell($alarm_types[$row['alarm_type']], $row['id'], '', 'right');
 			form_selectable_cell(($row['alarm_type'] == 0 ? $row['alarm_hi'] : ($row['alarm_type'] == 1 ? $row['time_hi'] : '')), $row['id'], '', 'right');
 			form_selectable_cell(($row['alarm_type'] == 0 ? $row['alarm_low'] : ($row['alarm_type'] == 1 ? $row['time_low'] : '')), $row['id'], '', 'right');
-			form_selectable_cell(($row['alarm_type'] == 0 ? ('<i>' . plugin_alarm_duration_convert($row['alarm_fail_trigger'], 'alert') . '</i>') : ($row['alarm_type'] == 1 ? ('<i>' . __('%d Triggers', $row['time_fail_trigger']) . '</i>') : '')), $row['id'], '', '');
-			form_selectable_cell(($row['alarm_type'] == 1 ? plugin_alarm_duration_convert($row['time_fail_length'], 'time') : ''), $row['id'], '', '');
-			form_selectable_cell(($row['repeat_alert'] == '' ? '' : plugin_alarm_duration_convert($row['repeat_alert'], 'repeat')), $row['id'], '', '');
+			form_selectable_cell(($row['alarm_type'] == 0 ? ('<i>' . plugin_alarm_duration_convert($row['alarm_fail_trigger'], 'alert') . '</i>') : ($row['alarm_type'] == 1 ? ('<i>' . __('%d Triggers', $row['time_fail_trigger']) . '</i>') : '')), $row['id'], '', 'right');
+			form_selectable_cell(($row['alarm_type'] == 1 ? plugin_alarm_duration_convert($row['time_fail_length'], 'time') : ''), $row['id'], '', 'right');
+			form_selectable_cell(($row['repeat_alert'] == '' ? '' : plugin_alarm_duration_convert($row['repeat_alert'], 'repeat')), $row['id'], '', 'right');
 
 			form_checkbox_cell($row['name'], $row['id'], '', '');
 			form_end_row();
 		}
 	} else {
-		print '<tr><td colspan=15><em>No Templates Found</em></td></tr>';
+		print '<tr><td colspan=15><em>' . __('No Alert Templates Found', 'gridalarms') . '</em></td></tr>';
 	}
 
 	html_end_box(false);
@@ -4616,28 +5324,28 @@ function list_templates($admin = true) {
 	}
 }
 
-function list_alarms($admin = true) {
+function list_alarms(bool $admin = true) : void {
 	global $alarm_bgcolors, $config, $alarm_actions, $alarm_types,
 		$frequencies, $grid_rows_selector, $gridalarms_types, $gridalarms_severities;
-	$sql_params = array();
 
 	alarm_request_validation($admin);
 
 	$statefilter = '';
 	$sql_where   = '';
+	$sql_params  = array();
 
 	if (isset_request_var('state')) {
 		if (get_request_var('state') != 0) {
 			if (get_request_var('state') == 1) {
-				$statefilter = "gridalarms_alarm.alarm_enabled='off'";
+				$statefilter = "gridalarms_alarm.alarm_enabled = 'off'";
 			}
 
 			if (get_request_var('state') == 2) {
-				$statefilter = "gridalarms_alarm.alarm_enabled='on'";
+				$statefilter = "gridalarms_alarm.alarm_enabled = 'on'";
 			}
 
 			if (get_request_var('state') == 3) {
-				$statefilter = 'gridalarms_alarm.alarm_alert!=0';
+				$statefilter = 'gridalarms_alarm.alarm_alert != 0';
 			}
 
 			if ($statefilter != '') {
@@ -4652,18 +5360,27 @@ function list_alarms($admin = true) {
 	}
 
 	if (isset_request_var('alarm_type') && get_request_var('alarm_type') != '-1') {
-		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_alarm.alarm_type=?';
+		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_alarm.alarm_type = ?';
 		$sql_params[] = get_request_var('alarm_type');
 	}
 
 	if (isset_request_var('clusterid') && get_request_var('clusterid') != '0') {
-		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_alarm.clusterid=?';
+		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_alarm.clusterid = ?';
 		$sql_params[] = get_request_var('clusterid');
+	}
+
+	if (isset_request_var('template_id')) {
+		if (get_request_var('template_id') > '0') {
+			$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_alarm.template_id = ?';
+			$sql_params[] = get_request_var('template_id');
+		} elseif (get_request_var('template_id') == '-1') {
+			$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_alarm.template_id = 0';
+		}
 	}
 
 	if (isset_request_var('filter') && get_request_var('filter') != '') {
 		$sql_where .= ($sql_where == '' ? 'WHERE ' : ' AND ') . 'gridalarms_alarm.name LIKE ?';
-		$sql_params[] = '%'. get_request_var('filter') . '%';
+		$sql_params[] = '%' . get_request_var('filter') . '%';
 	}
 
 	/* if the number of rows is -1, set it to the default */
@@ -4687,18 +5404,13 @@ function list_alarms($admin = true) {
 	$result = db_fetch_assoc_prepared($sql, $sql_params);
 
 	html_start_box(__('Alert Management', 'gridalarms') . rtm_hover_help('rtm_grid_alerts_create.html', __esc('Learn More', 'gridalarms')), '100%', '', '3', 'center', ($admin ? 'gridalarms_alarm_edit.php?action=select_template':''));
+
 	?>
 	<tr class='noprint even'>
 		<td>
 		<form id='listalarm' action='<?php print ($admin ? 'gridalarms_alarm.php':'grid_alarmdb.php');?>' method='get'>
 			<table class='filterTable'>
 				<tr>
-					<td>
-						<?php print __('Search', 'gridalarms');?>
-					</td>
-					<td>
-						<input type='text' id='filter' size='25' value='<?php print html_escape_request_var('filter');?>'>
-					</td>
 					<td>
 						<?php print __('Cluster', 'gridalarms');?>
 					</td>
@@ -4714,6 +5426,32 @@ function list_alarms($admin = true) {
 										print "<option value='" . $cluster["clusterid"] . "' selected>"  . html_escape($cluster["clustername"]) . "</option>";
 									} else {
 										print "<option value='" . $cluster["clusterid"] . "'>"  . html_escape($cluster["clustername"]) . "</option>";
+									}
+								}
+							}
+							?>
+						</select>
+					</td>
+					<td>
+						<?php print __('Template', 'gridalarms');?>
+					</td>
+					<td>
+						<select id='template_id' onChange='applyFilter()'>
+							<option value='0' <?php if (!isset_request_var('template_id') || get_request_var('template_id') == '0') print 'selected';?>>All</option>
+							<option value='-1' <?php if (!isset_request_var('template_id') || get_request_var('template_id') == '-1') print 'selected';?>>None</option>
+							<?php
+							$templates = db_fetch_assoc('SELECT DISTINCT gat.id, gat.name
+								FROM gridalarms_template AS gat
+								INNER JOIN gridalarms_alarm AS gaa
+								ON gat.id = gaa.template_id
+								ORDER BY gat.name');
+
+							if (cacti_sizeof($templates)) {
+								foreach ($templates as $t) {
+									if (isset_request_var('template_id') && (get_request_var('template_id') == $t['id'])) {
+										print "<option value='" . $t['id'] . "' selected>"  . html_escape($t['name']) . '</option>';
+									} else {
+										print "<option value='" . $t['id'] . "'>"  . html_escape($t['name']) . '</option>';
 									}
 								}
 							}
@@ -4741,6 +5479,12 @@ function list_alarms($admin = true) {
 			</table>
 			<table class='filterTable'>
 				<tr>
+					<td>
+						<?php print __('Search', 'gridalarms');?>
+					</td>
+					<td>
+						<input type='text' id='filter' size='25' value='<?php print html_escape(get_request_var('filter'));?>'>
+					</td>
 					<td>
 						<?php print __('Type', 'gridalarms');?>
 					</td>
@@ -4771,7 +5515,7 @@ function list_alarms($admin = true) {
 						</select>
 					</td>
 					<td>
-						Alerts
+						<?php print __('Alerts', 'gridalarms');?>
 					</td>
 					<td width='1'>
 						<select id='rows' onChange='applyFilter()'>
@@ -4793,6 +5537,7 @@ function list_alarms($admin = true) {
 			strURL += '&state=' + $('#state').val();
 			strURL += '&alarm_ds_type=' + $('#alarm_ds_type').val();
 			strURL += '&alarm_type=' + $('#alarm_type').val();
+			strURL += '&template_id=' + $('#template_id').val();
 			strURL += '&rows=' + $('#rows').val();
 			strURL += '&clusterid=' + $('#clusterid').val();
 			strURL += '&filter=' + $('#filter').val();
@@ -4826,28 +5571,99 @@ function list_alarms($admin = true) {
 	html_end_box();
 
 	$display_text = array(
-		'nosort0'            => array('display' => __('Actions', 'gridalarms'),      'sort' => 'ASC'),
-		'name'               => array('display' => __('Name', 'gridalarms'),         'sort' => 'ASC'),
-		'nosort1'            => array('display' => __('Cluster', 'gridalarms'),      'sort' => 'ASC'),
-		'syslog_priority'    => array('display' => __('Severity', 'gridalarms'),     'sort' => 'ASC'),
-		'frequency'          => array('display' => __('Check Freq', 'gridalarms'),   'sort' => 'ASC'),
-		'alarm_type'         => array('display' => __('Value Type', 'gridalarms'),   'sort' => 'ASC'),
-		'alarm_hi'           => array('display' => __('High', 'gridalarms'),         'sort' => 'ASC',  'align' => 'right'),
-		'alarm_low'          => array('display' => __('Low', 'gridalarms'),          'sort' => 'ASC',  'align' => 'right'),
-		'lastread'           => array('display' => __('Current', 'gridalarms'),      'sort' => 'ASC',  'align' => 'right'),
-		'alarm_fail_trigger' => array('display' => __('Trigger', 'gridalarms'),      'sort' => 'ASC'),
-		'time_fail_length'   => array('display' => __('Duration', 'gridalarms'),     'sort' => 'ASC'),
-		'repeat_alert'       => array('display' => __('Repeat Alert', 'gridalarms'), 'sort' => 'ASC'),
-		'last_runtime'       => array('display' => __('Last Checked', 'gridalarms'), 'sort' => 'DESC'),
-		'last_duration'      => array('display' => __('Run Time', 'gridalarms'),     'sort' => 'DESC', 'align' => 'right')
+		'nosort0' => array(
+			'display' => __('Actions', 'gridalarms'),
+			'sort' => 'ASC'
+		),
+		'name' => array(
+			'display' => __('Name', 'gridalarms'),
+			'sort' => 'ASC'
+		),
+		'nosort1' => array(
+			'display' => __('Cluster', 'gridalarms'),
+			'sort' => 'ASC'
+		),
+		'id' => array(
+			'display' => __('ID', 'gridalarms'),
+			'sort' => 'ASC',
+			'align' => 'right'
+		),
+		'syslog_priority' => array(
+			'display' => __('Severity', 'gridalarms'),
+			'sort' => 'ASC',
+			'align' => 'right'
+		),
+		'frequency' => array(
+			'display' => __('Check Freq', 'gridalarms'),
+			'sort' => 'ASC',
+			'align' => 'right'
+		),
+		'alarm_type' => array(
+			'display' => __('Value Type', 'gridalarms'),
+			'sort' => 'ASC',
+			'align' => 'right'
+		),
+		'alarm_hi' => array(
+			'display' => __('High', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'alarm_low' => array(
+			'display' => __('Low', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'lastread' => array(
+			'display' => __('Current', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'alarm_fail_trigger' => array(
+			'display' => __('Trigger', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'time_fail_length' => array(
+			'display' => __('Duration', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'repeat_alert' => array(
+			'display' => __('Repeat Alert', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		)
+	);
+
+	if ($admin) {
+		$display_text += array(
+			'template_enabled' => array(
+				'display' => __('Templated', 'gridalarms'),
+				'sort' => 'DESC',
+				'align' => 'right'
+			)
+		);
+	}
+
+	$display_text += array(
+		'last_runtime' => array(
+			'display' => __('Last Checked', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		),
+		'last_duration' => array(
+			'display' => __('Run Time', 'gridalarms'),
+			'sort' => 'DESC',
+			'align' => 'right'
+		)
 	);
 
 	$total_rows = db_fetch_cell_prepared("SELECT count(*) FROM gridalarms_alarm
 		LEFT JOIN gridalarms_expression
-		ON gridalarms_alarm.expression_id=gridalarms_expression.id
+		ON gridalarms_alarm.expression_id = gridalarms_expression.id
 		$sql_where", $sql_params);
 
-	$nav = html_nav_bar(($admin ? 'gridalarms_alarm.php':'grid_alarmdb.php'), MAX_DISPLAY_PAGES, get_request_var('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Alerts'), 'page', 'main');
+	$nav = html_nav_bar(($admin ? 'gridalarms_alarm.php':'grid_alarmdb.php'), MAX_DISPLAY_PAGES, get_request_var('page'), $rows, $total_rows, cacti_sizeof($display_text) + 1, __('Alerts', 'gridalarms'), 'page', 'main');
 
 	if ($admin) {
 		form_start('gridalarms_alarm.php', 'chk');
@@ -4863,22 +5679,23 @@ function list_alarms($admin = true) {
 		html_header_sort($display_text, get_request_var('sort_column'), get_request_var('sort_direction'));
 	}
 
-	$i=0;
-	$c=0;
+	$i = 0;
+	$c = 0;
+
 	if (cacti_sizeof($result)) {
 		foreach ($result as $row) {
 			$c++;
 
 			if ($row['alarm_alert'] != 0) {
-				$alertstat='yes';
+				$alertstat = 'yes';
 				if ($row["alarm_type"] == 0) {
-					$bgcolor=($row['alarm_fail_count'] >= $row['alarm_fail_trigger'] ? 'red' : 'yellow');
+					$bgcolor = ($row['alarm_fail_count'] >= $row['alarm_fail_trigger'] ? 'red' : 'yellow');
 				} else {
-					$bgcolor=($row['alarm_fail_count'] >= $row['time_fail_trigger'] ? 'red' : 'yellow');
+					$bgcolor = ($row['alarm_fail_count'] >= $row['time_fail_trigger'] ? 'red' : 'yellow');
 				}
 			} else {
-				$alertstat='no';
-				$bgcolor='green';
+				$alertstat = 'no';
+				$bgcolor = 'green';
 			}
 
 			if ($row['req_ack'] == 'on') {
@@ -4893,20 +5710,58 @@ function list_alarms($admin = true) {
 
 			if ($admin) {
 				if ($row['alarm_enabled'] == 'off') {
-					rtm_form_alternate_row_color($alarm_bgcolors['grey'], $alarm_bgcolors['grey'], 'line' . $row["id"], true);
+					rtm_form_alternate_row_color($alarm_bgcolors['grey'], $alarm_bgcolors['grey'], 'line' . $row["id"], false);
 				} else {
-					rtm_form_alternate_row_color($alarm_bgcolors[$bgcolor], $alarm_bgcolors[$bgcolor], 'line' . $row["id"], true);
+					rtm_form_alternate_row_color($alarm_bgcolors[$bgcolor], $alarm_bgcolors[$bgcolor], 'line' . $row["id"], false);
 				}
 
 				if ($row['expression_id'] > 0) {
 					print "<td class='nowrap' style='width:1%;'>";
-					print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') . "&action=details&tab=details&id=" . $row['id']) . "'><img title='" . __esc('View Currently Breached Items', 'gridalarms') . "' src='" . $config["url_path"] . "plugins/gridalarms/images/view_alarm_details.gif'></a>";
-					print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') . 'tab=log&id=' . $row['id'] . '&status=-1&alarm_type=-1&filter=') . "'><img title='" . __esc('View Alert History', 'gridalarms') . "' src='" . $config["url_path"] . "plugins/gridalarms/images/view_log.gif'></a>";
-					print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') . 'action=' . (alarm_enabled($row['id']) ? 'disable':'enable') . '&id=' . $row['id']) . "'><img title='" . (alarm_enabled($row['id']) ? __esc('Disable Alert Details', 'gridalarms'):__esc('Enable Alert Details', 'gridalarms')) . "' src='" . $config["url_path"] . "plugins/gridalarms/images/alarm_" . (alarm_enabled($row['id']) ? 'disable':'enable') . ".png'></a>";
-					print (alarm_acknowledge_enabled($row['id']) && alarm_acknowledge_required($row['id']) ? "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') . 'action=' . (alarm_acknowledge_required($row['id']) ? 'acknowledge':'resetack') . '&id=' . $row['id']) . "'><img title='" . (alarm_acknowledge_required($row['id']) ? __esc('Acknowledge Alert', 'gridalarms'):__esc('Reset Alert Acknowledgement', 'gridalarms')) . "' src='" . $config["url_path"] . 'plugins/gridalarms/images/alarm_' . (alarm_acknowledge_required($row['id']) ? 'ack':'reset') . ".png'></a>":'');
-					print "</td>\n";
+
+					print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+						"&action=details&tab=details&id=" . $row['id']) . "' title='" . __esc('View Currently Breached Items', 'gridalarms') . "'>
+						<i class='fas fa-search-plus'></i>
+					</a>";
+
+					print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+						'tab=log&id=' . $row['id'] .
+						'&status=-1&alarm_type=-1&filter=') . "' title='" . __esc('View Alert History', 'gridalarms') . "'>
+						<i class='tholdGlyphLog fas fa-exclamation-triangle'></i>
+					</a>";
+
+					if (alarm_enabled($row['id'])) {
+						print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+							'action=disable' .
+							'&id=' . $row['id']) . "' title='" . __esc('Disable Alert Details', 'gridalarms') . "'>
+							<i class='tholdGlyphDisable fas fa-stop-circle'></i>
+						</a>";
+					} else {
+						print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+							'action=enable' .
+							'&id=' . $row['id']) . "' title='" . __esc('Enable Alert Details', 'gridalarms') . "'>
+							<i class='tholdGlyphEnable fas fa-play-circle'></i>
+						</a>";
+					}
+
+					if (alarm_acknowledge_enabled($row['id']) && alarm_acknowledge_required($row['id'])) {
+						if (alarm_acknowledge_required($row['id'])) {
+							print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+								'action=acknowledge' .
+								'&id=' . $row['id']) . "' title='" . __esc('Acknowledge Alert', 'gridalarms') . "'>
+								<i class='tholdGlyphAcknowledge fas fa-clipboard-check'></i>
+							</a>";
+						} else {
+							print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+								'action=resetack' .
+								'&id=' . $row['id']) . "' title='" . __esc('Reset Alert Acknowledgement', 'gridalarms') . "'>
+								<i class='tholdGlyphAcknowledgeResume fas fa-clipboard-check'></i>
+							</a>";
+						}
+					}
+
+					print "</td>";
 				} else {
-					print "<td></td>\n";
+					print "<td></td>";
 				}
 
 				$name = ($row['name'] != '' ? $row['name'] : __('Unknown [%s]', $row['data_source_name'], 'gridalarms'));
@@ -4922,68 +5777,123 @@ function list_alarms($admin = true) {
 					form_selectable_cell($cluster_name, $row['id'], '', '');
 				}
 
-				form_selectable_cell($gridalarms_severities[$row['syslog_priority']], $row['id'], '', '');
-				form_selectable_cell($frequencies[$row['frequency']], $row['id'], '', '');
-				form_selectable_cell($alarm_types[$row['alarm_type']], $row['id'], '', '');
+				form_selectable_cell($row['id'], $row['id'], '', 'right');
+
+				form_selectable_cell($gridalarms_severities[$row['syslog_priority']], $row['id'], '', 'right');
+				form_selectable_cell($frequencies[$row['frequency']], $row['id'], '', 'right');
+				form_selectable_cell($alarm_types[$row['alarm_type']], $row['id'], '', 'right');
 				form_selectable_cell(($row['alarm_type'] == 0 ? $row['alarm_hi'] : ($row['alarm_type'] == 1 ? $row['time_hi'] : '')), $row['id'], '', 'right');
 				form_selectable_cell(($row['alarm_type'] == 0 ? $row['alarm_low'] : ($row['alarm_type'] == 1 ? $row['time_low'] : '')), $row['id'], '', 'right');
 				form_selectable_cell($row['lastread'], $row['id'], '', 'right');
-				form_selectable_cell(($row['alarm_type'] == 0 ? ('<i>' . plugin_alarm_duration_convert($row['alarm_fail_trigger'], 'alert') . '</i>') : ($row['alarm_type'] == 1 ? ('<i>' . __('%d Triggers', $row['time_fail_trigger'], 'gridalarms') . '</i>') : '')), $row['id'], '', '');
+				form_selectable_cell(($row['alarm_type'] == 0 ? ('<i>' . plugin_alarm_duration_convert($row['alarm_fail_trigger'], 'alert') . '</i>') : ($row['alarm_type'] == 1 ? ('<i>' . __('%d Triggers', $row['time_fail_trigger'], 'gridalarms') . '</i>') : '')), $row['id'], '', 'right');
 
-				form_selectable_cell(($row['alarm_type'] == 1 ? plugin_alarm_duration_convert($row['time_fail_length'], 'time') : ''), $row['id'], '', '');
-				form_selectable_cell(($row['repeat_alert'] == '' ? '' : plugin_alarm_duration_convert($row['repeat_alert'], 'repeat')), $row['id'], '', '');
+				form_selectable_cell(($row['alarm_type'] == 1 ? plugin_alarm_duration_convert($row['time_fail_length'], 'time') : ''), $row['id'], '', 'right');
+				form_selectable_cell(($row['repeat_alert'] == '' ? '' : plugin_alarm_duration_convert($row['repeat_alert'], 'repeat')), $row['id'], '', 'right');
 
-				form_selectable_cell(($row['last_runtime'] == '0000-00-00 00:00:00' ? __('N/A', 'gridalarms'):$row['last_runtime']), $row['id'], '', '');
-				form_selectable_cell(($row['last_runtime'] == '0000-00-00 00:00:00' ? __('N/A', 'gridalarms'):round($row['last_duration'], 3) . ' sec'), $row['id'], '', 'right');
+				form_selectable_cell(($row['template_enabled'] == 'on' ? __('Yes', 'gridalarms'):__('No', 'gridalarms')), $row['id'], '', 'right');
+
+				form_selectable_cell(($row['last_runtime'] == '0000-00-00 00:00:00' ? __('N/A', 'gridalarms'):$row['last_runtime']), $row['id'], '', 'right');
+				form_selectable_cell(($row['last_runtime'] == '0000-00-00 00:00:00' ? __('N/A', 'gridalarms'):round($row['last_duration'], 2) . ' sec'), $row['id'], '', 'right');
+
 				form_checkbox_cell($row['name'], $row['id'], '', '');
+
 				form_end_row();
 			} else {
 				if ($row['alarm_enabled'] == 'off') {
-					rtm_form_alternate_row_color($alarm_bgcolors['grey'], $alarm_bgcolors['grey']);
+					rtm_form_alternate_row_color($alarm_bgcolors['grey'], $alarm_bgcolors['grey'], 'line' . $row['id'], false);
 				} else {
-					rtm_form_alternate_row_color($alarm_bgcolors[$bgcolor], $alarm_bgcolors[$bgcolor]);
+					rtm_form_alternate_row_color($alarm_bgcolors[$bgcolor], $alarm_bgcolors[$bgcolor], 'line' . $row['id'], false);
 				}
 
 				$hasAuth = api_user_realm_auth('gridalarms_alarm_edit.php');
 
 				if ($row['expression_id'] > 0) {
 					print "<td class='nowrap' style='width:1%;'>";
-					print $hasAuth ? "<a class='pic' href='" . html_escape("gridalarms_alarm_edit.php?tab=general&id=" . $row['id']) . "'><img title='Edit Alert' src='" . $config["url_path"] . "plugins/gridalarms/images/edit_object.png'></a>":'';
-					print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') . 'action=details&tab=details&id=' . $row['id']) . "'><img title='" . __esc('View Currently Breached Items', 'gridalarms') . "' src='" . $config["url_path"] . "plugins/gridalarms/images/view_alarm_details.gif'></a>";
-					print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') . 'tab=log&id=' . $row['id'] . '&status=-1&alarm_type=-1&filter=') . "'><img title='" . __esc('View Alert History', 'gridalarms') . "' src='" . $config["url_path"] . "plugins/gridalarms/images/view_log.gif'></a>";
 
-					if (api_user_realm_auth('gridalarms_alarm.php')) {
-						print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') . 'action=' . (alarm_enabled($row['id']) ? 'disable':'enable') . '&id=' . $row['id']) . "'><img title='" . (alarm_enabled($row['id']) ? __esc('Disable Alert Details', 'gridalarms'): __esc('Enable Alert Details', 'gridalarms')) . "' src='" . $config["url_path"] . 'plugins/gridalarms/images/alarm_' . (alarm_enabled($row['id']) ? 'disable':'enable') . ".png'></a>";
-						print (alarm_acknowledge_enabled($row['id']) && alarm_acknowledge_required($row['id']) ? "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') . 'action=' . (alarm_acknowledge_required($row['id']) ? 'acknowledge':'resetack') . '&id=' . $row['id']) . "'><img title='" . (alarm_acknowledge_required($row['id']) ? __esc('Acknowledge Alert', 'gridalarms'):__esc('Reset Alert Acknowledgement', 'gridalarms')) . "' src='" . $config["url_path"] . 'plugins/gridalarms/images/alarm_' . (alarm_acknowledge_required($row['id']) ? 'ack':'reset') . ".png'></a>":'');
+					if ($hasAuth) {
+						print "<a class='pic' href='" . html_escape("gridalarms_alarm_edit.php?tab=general&id=" . $row['id']) . "' title='" . __esc('Edit Alert', 'gridalarms') . "'>
+						<i class='tholdGlyphEdit fas fa-wrench'></i>
+						</a>";
 					}
 
-					print "</td>\n";
+					print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+						'action=details&tab=details&id=' . $row['id']) . "' title='" . __esc('View Currently Breached Items', 'gridalarms') . "'>
+						<i class='fas fa-search-plus'></i>
+					</a>";
+
+					print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+						'tab=log&id=' . $row['id'] . '&status=-1&alarm_type=-1&filter=') . "' title='" . __esc('View Alert History', 'gridalarms') . "'>
+						<i class='tholdGlyphLog fas fa-exclamation-triangle'></i>
+					</a>";
+
+					if (api_user_realm_auth('gridalarms_alarm.php')) {
+						if (alarm_enabled($row['id'])) {
+							print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+								'action=disable' .
+								'&id=' . $row['id']) . "' title='" . __esc('Disable Alert Details', 'gridalarms') . "'>
+								<i class='tholdGlyphDisable fas fa-stop-circle'></i>
+							</a>";
+						} else {
+							print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+								'action=enable' .
+								'&id=' . $row['id']) . "' title='" . __esc('Enable Alert Details', 'gridalarms') . "'>
+								<i class='tholdGlyphEnable fas fa-play-circle'></i>
+							</a>";
+						}
+
+						if (alarm_acknowledge_enabled($row['id']) && alarm_acknowledge_required($row['id'])) {
+							if (alarm_acknowledge_required($row['id'])) {
+								print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+									'action=acknowledge' .
+									'&id=' . $row['id']) . "' title='" . __esc('Acknowledge Alert', 'gridalarms') . "'>
+									<i class='tholdGlyphAcknowledge fas fa-clipboard-check'></i>
+								</a>";
+							} else {
+								print "<a class='pic' href='" . html_escape(($admin ? 'gridalarms_alarm.php?':'grid_alarmdb.php?') .
+									'action=resetack' .
+									'&id=' . $row['id']) . "' title='" . __esc('Reset Alert Acknowledgement', 'gridalarms') . "'>
+									<i class='tholdGlyphAcknowledgeResume fas fa-clipboard-check'></i>
+								</a>";
+							}
+						}
+					}
+
+					print "</td>";
+				} elseif ($hasAuth) {
+					print "<td class='nowrap' style='width:1%;'><a class='pic' href='" . html_escape("gridalarms_alarm_edit.php?tab=general&id=" . $row['id']) . "' title='" . __('Edit Alert', 'gridalarms') . "'>
+						<i class='tholdGlyphEdit fas fa-wrench'></i>
+					</a></td>";
 				} else {
-					print "<td class='nowrap' style='width:1%;'>" . ($hasAuth ? "<a class='pic' href='" . html_escape("gridalarms_alarm_edit.php?tab=general&id=" . $row['id']) . "'><img title='Edit Alert' src='" . $config["url_path"] . "plugins/gridalarms/images/edit_object.png'></a>":"") . "</td>\n";
+					print "<td class='nowrap' style='width:1%;'></td>";
 				}
 
-				print "<td>" . ($row["name"] != "" ? html_escape($row["name"]) : " [" . html_escape($row['data_source_name']) . "]") . "</td>\n";
+				form_selectable_cell(($row['name'] != '' ? html_escape($row['name']):' [' . html_escape($row['data_source_name']) . ']'), $row['id']);
 
 				if ($row["clusterid"] == '0') {
-					print "<td style=''>" . __('N/A', 'gridalarms') . "</td>\n";
+					form_selectable_cell( __('N/A', 'gridalarms'), $row['id']);
 				} else {
 					$cluster_name = get_clustername($row['clusterid']);
 					$cluster_name = isset($cluster_name)? $cluster_name:__('N/A', 'gridalarms');
-					print "<td>" . html_escape($cluster_name) . "</td>\n";
+					form_selectable_cell(html_escape($cluster_name), $row['id']);
 				}
 
-				print "<td>" . $gridalarms_severities[$row['syslog_priority']] . "</td>\n";
-				print "<td>" . $frequencies[$row['frequency']] . "</td>\n";
-				print "<td>" . $alarm_types[$row['alarm_type']] . "</td>\n";
-				print "<td class='right'>" . ($row['alarm_type'] == 0 ? $row['alarm_hi'] : ($row['alarm_type'] == 1 ? $row['time_hi'] : '')) . "</td>\n";
-				print "<td class='right'>" . ($row['alarm_type'] == 0 ? $row['alarm_low'] : ($row['alarm_type'] == 1 ? $row['time_low'] : '')) . "</td>\n";
-				print "<td class='right'>" . $row['lastread'] . "</td>\n";
-				print "<td>" . ($row['alarm_type'] == 0 ? ("<i>" . plugin_alarm_duration_convert($row['alarm_fail_trigger'], 'alert') . "</i>") : ($row['alarm_type'] == 1 ? ("<i>" . $row['time_fail_trigger'] . " Triggers</i>") : '')) . "</td>\n";
-				print "<td>" . ($row['alarm_type'] == 1 ? plugin_alarm_duration_convert($row['time_fail_length'], 'time') : '') . "</td>\n";
-				print "<td>" . ($row['repeat_alert'] == '' ? '' : plugin_alarm_duration_convert($row['repeat_alert'], 'repeat')) . "</td>\n";
+				form_selectable_cell($row['id'], $row['id'], '', 'right');
 
-				print "<td>" . ($row['last_runtime'] == '0000-00-00 00:00:00' ? __('N/A', 'gridalarms'):$row['last_runtime']) . "</td>\n";
-				print "<td class='right'>" . ($row['last_runtime'] == '0000-00-00 00:00:00' ? __('N/A', 'gridalarms'):round($row['last_duration'], 4) . " sec") . "</td>\n";
+				form_selectable_cell($gridalarms_severities[$row['syslog_priority']], $row['id'], '', 'right');
+				form_selectable_cell($frequencies[$row['frequency']], $row['id'], '', 'right');
+				form_selectable_cell($alarm_types[$row['alarm_type']], $row['id'], '', 'right');
+
+				form_selectable_cell(($row['alarm_type'] == 0 ? $row['alarm_hi'] : ($row['alarm_type'] == 1 ? $row['time_hi'] : '')), $row['id'], '', 'right');
+				form_selectable_cell(($row['alarm_type'] == 0 ? $row['alarm_low'] : ($row['alarm_type'] == 1 ? $row['time_low'] : '')), $row['id'], '', 'right');
+				form_selectable_cell($row['lastread'], $row['id'], '', 'right');
+
+				form_selectable_cell(($row['alarm_type'] == 0 ? ("<i>" . plugin_alarm_duration_convert($row['alarm_fail_trigger'], 'alert') . "</i>") : ($row['alarm_type'] == 1 ? ("<i>" . $row['time_fail_trigger'] . " Triggers</i>") : '')), $row['id'], '', 'right');
+
+				form_selectable_cell(($row['alarm_type'] == 1 ? plugin_alarm_duration_convert($row['time_fail_length'], 'time') : ''), $row['id'], '', 'right');
+				form_selectable_cell(($row['repeat_alert'] == '' ? '' : plugin_alarm_duration_convert($row['repeat_alert'], 'repeat')), $row['id'], '', 'right');
+
+				form_selectable_cell(($row['last_runtime'] == '0000-00-00 00:00:00' ? __('N/A', 'gridalarms'):$row['last_runtime']), $row['id'], '', 'right');
+				form_selectable_cell(($row['last_runtime'] == '0000-00-00 00:00:00' ? __('N/A', 'gridalarms'):round($row['last_duration'], 2) . " sec"), $row['id'], '', 'right');
 			}
 		}
 	} else {
@@ -5004,89 +5914,16 @@ function list_alarms($admin = true) {
 	}
 }
 
-function alarm_log_purge() {
-	db_execute("TRUNCATE gridalarms_alarm_log");
+function alarm_log_purge() : void {
+	db_execute('TRUNCATE gridalarms_alarm_log');
 }
 
-function api_alarm_remove($alarm_id){
-	$expression_id = db_fetch_cell_prepared('SELECT expression_id
-		FROM gridalarms_alarm
-		WHERE id = ?',
-		array($alarm_id));
-
-	/* delete non relational data first */
-	db_execute_prepared('DELETE FROM gridalarms_alarm
-		WHERE id = ?',
-		array($alarm_id));
-
-	db_execute_prepared('DELETE FROM gridalarms_alarm_contacts
-		WHERE alarm_id = ?',
-		array($alarm_id));
-
-	db_execute_prepared('DELETE FROM gridalarms_alarm_layout
-		WHERE alarm_id = ?',
-		array($alarm_id));
-
-	db_execute_prepared('DELETE FROM gridalarms_alarm_log
-		WHERE alarm_id = ?',
-		array($alarm_id));
-
-	db_execute_prepared('DELETE FROM gridalarms_alarm_log_items
-		WHERE alarm_id = ?',
-		array($alarm_id));
-
-	api_plugin_hook_function('gridalarms_delete_hostsalarm',$alarm_id);
-
-	/* delete the expression next */
-	if (!empty($expression_id)) {
-		db_execute_prepared('DELETE FROM gridalarms_expression
-			WHERE id = ?',
-			array($expression_id));
-
-		db_execute_prepared('DELETE FROM gridalarms_expression_input
-			WHERE expression_id = ?',
-			array($expression_id));
-
-		db_execute_prepared('DELETE FROM gridalarms_expression_item
-			WHERE expression_id = ?',
-			array($expression_id));
-
-		/* remove any non-shared metrics */
-		$metrics = db_fetch_assoc_prepared('SELECT metric_id
-			FROM gridalarms_metric_expression
-			WHERE expression_id = ?',
-			array($expression_id));
-
-		if (cacti_sizeof($metrics)) {
-			foreach ($metrics as $m) {
-				$shared_metric = db_fetch_cell_prepared('SELECT COUNT(*)
-					FROM gridalarms_metric_expression
-					WHERE metric_id = ?
-					AND expression_id != ?',
-					array($m['metric_id'], $expression_id));
-
-				if (!$shared_metric) {
-					db_execute_prepared('DELETE FROM gridalarms_metric
-						WHERE id = ?',
-						array($m['metric_id']));
-				}
-			}
-		}
-
-		/* remove any relationship of the expression to the metric */
-		db_execute_prepared('DELETE FROM gridalarms_metric_expression WHERE expression_id=?', array($expression_id));
-	}
-}
-
-function api_alarm_remove_multi(){
-	;
-}
-
-function do_alarms($from = 'console') {
+function do_alarms(string $from = 'console') : void {
 	global $config;
 
-	$alarms = array();
+	$alarms   = array();
 	$question = "";
+
 	foreach ($_POST as $var => $val) {
 		if (preg_match("/^chk_(.*)$/", $var, $matches)) {
 			$del = $matches[1];
@@ -5096,6 +5933,7 @@ function do_alarms($from = 'console') {
 				array($del));
 
 			input_validate_input_number($del);
+
 			$alarms[$del] = $rra;
 		}
 	}
@@ -5107,11 +5945,80 @@ function do_alarms($from = 'console') {
 
 				if ($alarm != false) {
 					foreach ($alarm as $del => $me) {
-						api_alarm_remove($del);
+						$expression_id = db_fetch_cell_prepared('SELECT expression_id
+							FROM gridalarms_alarm
+							WHERE id = ?',
+							array($del));
+
+						/* delete non relational data first */
+						db_execute_prepared('DELETE FROM gridalarms_alarm
+							WHERE id = ?',
+							array($del));
+
+						db_execute_prepared('DELETE FROM gridalarms_alarm_contacts
+							WHERE alarm_id = ?',
+							array($del));
+
+						db_execute_prepared('DELETE FROM gridalarms_alarm_layout
+							WHERE alarm_id = ?',
+							array($del));
+
+						db_execute_prepared('DELETE FROM gridalarms_alarm_log
+							WHERE alarm_id = ?',
+							array($del));
+
+						db_execute_prepared('DELETE FROM gridalarms_alarm_log_items
+							WHERE alarm_id = ?',
+							array($del));
+
+						api_plugin_hook_function('gridalarms_delete_hostsalarm',$del);
+
+						/* delete the expression next */
+						if (!empty($expression_id)) {
+							db_execute_prepared('DELETE FROM gridalarms_expression
+								WHERE id = ?',
+								array($expression_id));
+
+							db_execute_prepared('DELETE FROM gridalarms_expression_input
+								WHERE expression_id = ?',
+								array($expression_id));
+
+							db_execute_prepared('DELETE FROM gridalarms_expression_item
+								WHERE expression_id = ?',
+								array($expression_id));
+
+							/* remove any non-shared metrics */
+							$metrics = db_fetch_assoc_prepared('SELECT metric_id
+								FROM gridalarms_metric_expression
+								WHERE expression_id = ?',
+								array($expression_id));
+
+							if (cacti_sizeof($metrics)) {
+								foreach ($metrics as $m) {
+									$shared_metric = db_fetch_cell_prepared('SELECT COUNT(*)
+										FROM gridalarms_metric_expression
+										WHERE metric_id = ?
+										AND expression_id != ?',
+										array($m['metric_id'], $expression_id));
+
+									if (!$shared_metric) {
+										db_execute_prepared('DELETE FROM gridalarms_metric
+											WHERE id = ?',
+											array($m['metric_id']));
+									}
+								}
+							}
+
+							/* remove any relationship of the expression to the metric */
+							db_execute_prepared('DELETE FROM gridalarms_metric_expression
+								WHERE expression_id = ?',
+								array($expression_id));
+						}
 					}
 				}
 
 				header('Location:gridalarms_alarm.php');
+
 				exit;
 			}
 
@@ -5122,7 +6029,7 @@ function do_alarms($from = 'console') {
 			if (cacti_sizeof($alarms) == 0) {
 				raise_message(40, __("You must select at least one alert."), MESSAGE_LEVEL_ERROR);
 				header('Location: gridalarms_alarm.php?header=false');
-				// header('Location: gridalarms_template_edit.php?action=edit&header=false&id=' . get_request_var('id') . '&tab=' . get_request_var('tab'));
+
 				exit;
 			} else {
 				$alarm_list = '';
@@ -5178,13 +6085,17 @@ function do_alarms($from = 'console') {
 				if ($alarm != false) {
 					foreach ($alarm as $del => $rra) {
 						//plugin_alarm_log_changes($del, 'disabled_alarm', array('id' => $del));
-						db_execute_prepared("UPDATE gridalarms_alarm SET alarm_enabled='off' WHERE id=?", array($del));
+						db_execute_prepared("UPDATE gridalarms_alarm
+							SET alarm_enabled='off'
+							WHERE id = ?",
+							array($del));
 					}
 				}
 
 				header('Location:gridalarms_alarm.php');
 				exit;
 			}
+
 			top_header();
 
 			form_start('gridalarms_alarm.php');
@@ -5192,7 +6103,7 @@ function do_alarms($from = 'console') {
 			if (cacti_sizeof($alarms) == 0) {
 				raise_message(40, __("You must select at least one alert."), MESSAGE_LEVEL_ERROR);
 				header('Location: gridalarms_alarm.php?header=false');
-				// header('Location: gridalarms_alarm.php?action=edit&header=false&id=' . get_request_var('id') . '&tab=' . get_request_var('tab'));
+
 				exit;
 			} else {
 				$alarm_list = '';
@@ -5215,7 +6126,7 @@ function do_alarms($from = 'console') {
 					<td class='textArea'>
 						<p>" . __('Click \'Continue\' to Disable the following Alert(s).', 'gridalarms') . "</p>
 						<div class='itemlist'>
-							<ul> $alarm_list</ul>
+							<ul>$alarm_list</ul>
 						</div>";
 
 				print "</td></tr>\n";
@@ -5244,10 +6155,12 @@ function do_alarms($from = 'console') {
 				$alarm = sanitize_unserialize_selected_items(get_nfilter_request_var('selected_items'), false);
 
 				if ($alarm != false) {
-				foreach ($alarm as $del => $rra) {
-					//plugin_alarm_log_changes($del, 'enabled_alarm', array('id' => $del));
-					db_execute_prepared("UPDATE gridalarms_alarm SET alarm_enabled='on' WHERE id=?", array($del));
-				}
+					foreach ($alarm as $del => $rra) {
+						db_execute("UPDATE gridalarms_alarm
+							SET alarm_enabled='on'
+							WHERE id = ?",
+							array($del));
+					}
 				}
 
 				header('Location:gridalarms_alarm.php');
@@ -5261,7 +6174,7 @@ function do_alarms($from = 'console') {
 			if (cacti_sizeof($alarms) == 0) {
 				raise_message(40, __("You must select at least one alert."), MESSAGE_LEVEL_ERROR);
 				header('Location: gridalarms_alarm.php?header=false');
-				// header('Location: gridalarms_alarm.php?action=edit&header=false&id=' . get_request_var('id') . '&tab=' . get_request_var('tab'));
+
 				exit;
 			} else {
 				$alarm_list = '';
@@ -5477,15 +6390,16 @@ function do_alarms($from = 'console') {
 	}
 }
 
-function do_templates() {
+function do_templates() : void {
 	global $config;
 
-	$alarms = array();
+	$alarms   = array();
 	$question = "";
+
 	foreach ($_POST as $var => $val) {
 		if (preg_match("/^chk_(.*)$/", $var, $matches)) {
 			$del = $matches[1];
-			$rra = db_fetch_cell_prepared('SELECT id FROM gridalarms_template WHERE id=?', array($del));
+			$rra = db_fetch_cell('SELECT id FROM gridalarms_template WHERE id=' . $del);
 
 			input_validate_input_number($del);
 			$alarms[$del] = $rra;
@@ -5499,36 +6413,54 @@ function do_templates() {
 
 				if ($alarm != false) {
 					foreach ($alarm as $del => $me) {
-						$expression_id = db_fetch_cell_prepared('SELECT expression_id FROM gridalarms_template WHERE id=?', array($del));
+						$expression_id = db_fetch_cell_prepared('SELECT expression_id
+							FROM gridalarms_template
+							WHERE id = ?',
+							array($del));
 
 						/* delete non relational data first */
-						db_execute_prepared('DELETE FROM gridalarms_template WHERE id=?', array($del));
-						db_execute_prepared('DELETE FROM gridalarms_template_contacts WHERE alarm_id=?', array($del));
-						db_execute_prepared('DELETE FROM gridalarms_template_layout WHERE alarm_id=?', array($del));
+						db_execute_prepared('DELETE FROM gridalarms_template WHERE id = ?', array($del));
+						db_execute_prepared('DELETE FROM gridalarms_template_contacts WHERE alarm_id = ?', array($del));
+						db_execute_prepared('DELETE FROM gridalarms_template_layout WHERE alarm_id = ?', array($del));
 
 						/* delete the expression next */
 						if (!empty($expression_id)) {
-							db_execute_prepared('DELETE FROM gridalarms_template_expression WHERE id=?', array($expression_id));
-							db_execute_prepared('DELETE FROM gridalarms_template_expression_input WHERE expression_id=?', array($expression_id));
-							db_execute_prepared('DELETE FROM gridalarms_template_expression_item WHERE expression_id=?', array($expression_id));
+							db_execute_prepared('DELETE FROM gridalarms_template_expression WHERE id = ?', array($expression_id));
+							db_execute_prepared('DELETE FROM gridalarms_template_expression_input WHERE expression_id = ?', array($expression_id));
+							db_execute_prepared('DELETE FROM gridalarms_template_expression_item WHERE expression_id = ?', array($expression_id));
 
 							/* remove any non-shared metrics */
-							$metrics = db_fetch_assoc_prepared('SELECT metric_id FROM gridalarms_template_metric_expression WHERE expression_id=?', array($expression_id));
+							$metrics = db_fetch_assoc_prepared('SELECT metric_id
+								FROM gridalarms_template_metric_expression
+								WHERE expression_id = ?',
+								array($expression_id));
+
 							if (cacti_sizeof($metrics)) {
 								foreach ($metrics as $m) {
-									$shared_metric = db_fetch_cell_prepared('SELECT count(*) FROM gridalarms_template_metric_expression WHERE metric_id=? AND expression_id!=?', array($m['metric_id'], $expression_id));
+									$shared_metric = db_fetch_cell_prepared('SELECT COUNT(*)
+										FROM gridalarms_template_metric_expression
+										WHERE metric_id = ?
+										AND expression_id != ?',
+										array($m['metric_id'], $expression_id));
 
 									if (!$shared_metric) {
-										db_execute_prepared('DELETE FROM gridalarms_template_metric WHERE id=?', array($m['metric_id']));
+										db_execute_prepared('DELETE FROM gridalarms_template_metric
+											WHERE id = ?',
+											array($m['metric_id']));
 									}
 								}
 							}
 
 							/* remove any relationship of the expression to the metric */
-							db_execute_prepared('DELETE FROM gridalarms_template_metric_expression WHERE expression_id=?', array($expression_id));
+							db_execute_prepared('DELETE FROM gridalarms_template_metric_expression
+								WHERE expression_id = ?',
+								array($expression_id));
 
 							/* untemplate all alarms */
-							db_execute_prepared("UPDATE gridalarms_alarm SET template_id=0, template_enabled='' WHERE template_id=?", array($del));
+							db_execute_prepared("UPDATE gridalarms_alarm
+								SET template_id = 0, template_enabled = ''
+								WHERE template_id = ?",
+								array($del));
 						}
 					}
 				}
@@ -5673,6 +6605,7 @@ function do_templates() {
 				// header('Location: gridalarms_templates.php?action=edit&header=false&id=' . get_request_var('id') . '&tab=' . get_request_var('tab'));
 				exit;
 			}
+
 			top_header();
 
 			print '<script text="text/javascript">
@@ -5692,11 +6625,12 @@ function do_templates() {
 			<iframe id="download_iframe" style="display:none;"></iframe>';
 
 			bottom_footer();
+
 			exit;
 	}
 }
 
-function check_import_xml_gridalarms_template($xml_data, &$dup_alarm_array) {
+function check_import_xml_gridalarms_template(string $xml_data, array &$dup_alarm_array) : int {
 	global $config, $hash_type_codes, $hash_version_codes;
 
 	include_once($config['library_path'] . '/xml.php');
@@ -5749,10 +6683,11 @@ function check_import_xml_gridalarms_template($xml_data, &$dup_alarm_array) {
 
 	//restore the hash_type_codes
 	$hash_type_codes = $hash_type_codes_bak;
+
 	return cacti_sizeof($dup_alarm_array);
 }
 
-function import_xml_gridalarms_template($xml_data) {
+function import_xml_gridalarms_template(string $xml_data) : void {
 	global $config, $hash_type_codes, $hash_version_codes;
 
 	include_once($config['library_path'] . '/xml.php');
@@ -5773,7 +6708,7 @@ function import_xml_gridalarms_template($xml_data) {
 	if (cacti_sizeof($xml_array) == 0) {
 		raise_message(7); /* xml parse error */
 		$hash_type_codes = $hash_type_codes_bak;
-		return ;
+		return;
 	}
 
 	foreach ($xml_array as $hash => $hash_array) {
@@ -5803,11 +6738,12 @@ function import_xml_gridalarms_template($xml_data) {
 			return;
 		}
 	}
+
 	//restore the hash_type_codes
 	$hash_type_codes = $hash_type_codes_bak;
 }
 
-function import_single_template($alarm_hash,$hash_array,&$ret) {
+function import_single_template(string $alarm_hash,array $hash_array, int &$ret) : void {
 	global $config;
 	global $struct_gridalarms_template, $struct_gridalarms_template_contacts, $struct_gridalarms_template_expression;
 	global $struct_gridalarms_template_expression_input,$struct_gridalarms_template_expression_item, $struct_gridalarms_template_layout;
@@ -6109,7 +7045,7 @@ function import_single_template($alarm_hash,$hash_array,&$ret) {
 	}
 }
 
-function export_gridalarms_template($alarm) {
+function export_gridalarms_template(array $alarm) : string {
 	global $struct_gridalarms_template, $struct_gridalarms_template_contacts, $struct_gridalarms_template_expression;
 	global $struct_gridalarms_template_expression_input,$struct_gridalarms_template_expression_item, $struct_gridalarms_template_layout;
 	global $struct_gridalarms_template_metric, $struct_gridalarms_template_metric_expression;
@@ -6300,10 +7236,11 @@ function export_gridalarms_template($alarm) {
 
 	//restore the hash_type_codes
 	$hash_type_codes = $hash_type_codes_bak;
+
 	return $xml_text;
 }
 
-function duplicate_gridalarms_template($alarm,$title_format) {
+function duplicate_gridalarms_template(array $alarm, string $title_format) : void {
 	$save = array();
 
 	//1. duplicate gridalarms_template_expression
@@ -6423,7 +7360,7 @@ function duplicate_gridalarms_template($alarm,$title_format) {
 	}
 }
 
-function template_propagation($type, $id) {
+function template_propagation(string $type, int $id) : ?bool {
 	$struct_gridalarms_template_prop = array(
 		'type',
 		'aggregation',
@@ -6436,7 +7373,10 @@ function template_propagation($type, $id) {
 		'syslog_priority',
 		'syslog_facility',
 		'syslog_enabled',
-		'tcheck'
+		'format_file',
+		'tcheck',
+		'external_id',
+		'notes'
 	);
 
 	$struct_gridalarms_template_expression_prop = array(
@@ -6532,8 +7472,8 @@ function template_propagation($type, $id) {
 
 		$template_expression_id = $gridalarms_template['expression_id'];
 
-		cacti_log('DEBUG: template_id=' . $template_id .' instance_id=' . $instance_id, false, 'GRIDALERTS', POLLER_VERBOSITY_DEBUG);
-		cacti_log('DEBUG: template_expression_id=' . $template_expression_id . ' instance_expression_id=' . $instance_expression_id, false, 'GRIDALERTS', POLLER_VERBOSITY_DEBUG);
+		//cacti_log('DEBUG: template_id=' . $template_id .' instance_id=' . $instance_id);
+		//cacti_log('DEBUG: template_expression_id=' . $template_expression_id . ' instance_expression_id=' . $instance_expression_id);
 
 		foreach ($struct_gridalarms_template_prop as $field_name) {
 			$gridalarms_alarm[$field_name] = $gridalarms_template[$field_name];
@@ -6592,8 +7532,9 @@ function template_propagation($type, $id) {
 			array($instance_id, $template_id));
 
 		db_execute_prepared("INSERT INTO gridalarms_alarm_layout
+			(id, alarm_id, template_id, display_name, column_name, sequence, sortposition, sortdirection, type, units, align, digits, autoscale)
 			SELECT 0, $instance_id, $template_id, display_name,
-			column_name,sequence, sortposition, sortdirection
+			column_name, sequence, sortposition, sortdirection, type, units, align, digits, autoscale
 			FROM gridalarms_template_layout
 			WHERE alarm_id = ?",
 			array($template_id));
@@ -6643,9 +7584,11 @@ function template_propagation($type, $id) {
 		//8. propogate gridalarms_template_metric_expression to gridalarms_metric_expression
 		push_out_metrics_items($template_expression_id, $instance_expression_id, $instance_id, $template_id);
 	}
+
+	return true;
 }
 
-function push_out_layout($alarm_id, $template_id) {
+function push_out_layout(int $alarm_id, int $template_id) : void {
 	/* remove any existing entries */
 	db_execute_prepared('DELETE FROM gridalarms_alarm_layout
 		WHERE alarm_id = ?',
@@ -6672,7 +7615,7 @@ function push_out_layout($alarm_id, $template_id) {
 	}
 }
 
-function push_out_metrics_items($template_expression_id, $expression_id, $alarm_id, $template_id) {
+function push_out_metrics_items(int $template_expression_id, int $expression_id, int $alarm_id, int $template_id) : void {
 	/* handle metrics first, it will simplify things */
 	$metrics = db_fetch_assoc_prepared('SELECT gtm.*
 		FROM gridalarms_template_metric AS gtm
@@ -6692,10 +7635,11 @@ function push_out_metrics_items($template_expression_id, $expression_id, $alarm_
 			unset($save['hash']);
 
 			/* check to see if the metric already exists */
-			$mid = db_fetch_cell_prepared("SELECT id
+			$mid = db_fetch_cell_prepared('SELECT id
 				FROM gridalarms_metric
-				WHERE db_table=?
-				AND db_column=?", array($m['db_table'], $m['db_column']));
+				WHERE db_table = ?
+				AND db_column = ?',
+				array($m['db_table'], $m['db_column']));
 
 			if (empty($mid)) {
 				$new_name   = $save['name'];
@@ -6714,7 +7658,7 @@ function push_out_metrics_items($template_expression_id, $expression_id, $alarm_
 			/* add to the mapping table */
 			db_execute_prepared('REPLACE INTO gridalarms_metric_expression
 				(metric_id, expression_id) VALUES
-				(?, ?, ?)',
+				(?, ?)',
 				array($mid, $expression_id));
 
 			/* we keep mappings so we can handle expressions type=3 */
@@ -6788,10 +7732,14 @@ function push_out_metrics_items($template_expression_id, $expression_id, $alarm_
 
 /**
  * this function will re-template an alarm, which can be distructive
- * @parm alarm_id			- (int) defines the alarm to retemplate
- * @returns					- null
+ *
+ * @param  array $alarm defines the alarm to retemplate
+ * @param  int   $template_id the template id of the object
+ @ @param  bool  $repush should the object be repushed
+ *
+ * @return int the id pushed out
  */
-function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
+function push_out_template_to_alarm(array $alarm, int $template_id = 0, bool $repush = false) : int {
 	$columns = array_rekey(
 		db_fetch_assoc('SHOW COLUMNS
 			FROM gridalarms_alarm'),
@@ -6799,6 +7747,7 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 	);
 
 	$id = 0;
+
 	if (cacti_sizeof($alarm)) {
 		if ((isset($alarm['template_id']) && isset($alarm['id'])) || (!empty($template_id))) {
 			/* get the template */
@@ -6813,20 +7762,23 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 					WHERE id = ?',
 					array($alarm['id']));
 
-        		$save['id']               = $alarm['id'];
-		        $save['template_id']      = isset($alarm['template_id']) ? $alarm['template_id']:$oldalarm['template_id'];
+				$save['id']               = $alarm['id'];
+				$save['template_id']      = isset($alarm['template_id'])    ? $alarm['template_id']:$oldalarm['template_id'];
 				$save['template_enabled'] = 'on';
-       			$save['name']             = isset($alarm['name']) ? $alarm['name']:$oldalarm['name'];
-				$save['clusterid']        = isset($alarm['clusterid']) ? $alarm['clusterid']:$oldalarm['clusterid'];
-				$save['expression_id']    = isset($alarm['expression_id']) ? $alarm['expression_id']:$oldalarm['expression_id'];
-				$save['email_subject']    = isset($alarm['email_subject']) ? $alarm['email_subject']:$oldalarm['email_subject'];
-				$save['email_body']       = isset($alarm['email_body']) ? $alarm['email_body']:$oldalarm['email_body'];
-				$save['notify_users']     = isset($alarm['notify_users']) ? $alarm['notify_users']:$oldalarm['notify_users'];
-				$save['notify_alert']     = isset($alarm['notify_alert']) ? $alarm['notify_alert']:$oldalarm['notify_alert'];
-				$save['notify_extra']     = isset($alarm['notify_extra']) ? $alarm['notify_extra']:$oldalarm['notify_extra'];
-				$save['req_ack']          = isset($alarm['req_ack']) ? $alarm['req_ack']:$oldalarm['req_ack'];
+				$save['name']             = isset($alarm['name'])           ? $alarm['name']:$oldalarm['name'];
+				$save['clusterid']        = isset($alarm['clusterid'])      ? $alarm['clusterid']:$oldalarm['clusterid'];
+				$save['expression_id']    = isset($alarm['expression_id'])  ? $alarm['expression_id']:$oldalarm['expression_id'];
+				$save['email_subject']    = isset($alarm['email_subject'])  ? $alarm['email_subject']:$oldalarm['email_subject'];
+				$save['email_body']       = isset($alarm['email_body'])     ? $alarm['email_body']:$oldalarm['email_body'];
+				$save['format_file']      = isset($alarm['format_file'])    ? $alarm['format_file']:$oldalarm['format_file'];
+				$save['notify_users']     = isset($alarm['notify_users'])   ? $alarm['notify_users']:$oldalarm['notify_users'];
+				$save['notify_alert']     = isset($alarm['notify_alert'])   ? $alarm['notify_alert']:$oldalarm['notify_alert'];
+				$save['notify_extra']     = isset($alarm['notify_extra'])   ? $alarm['notify_extra']:$oldalarm['notify_extra'];
+				$save['req_ack']          = isset($alarm['req_ack'])        ? $alarm['req_ack']:$oldalarm['req_ack'];
 				$save['syslog_enabled']   = isset($alarm['syslog_enabled']) ? $alarm['syslog_enabled']:$oldalarm['syslog_enabled'];
-				$save['exempt']           = isset($alarm['exempt']) ? $alarm['exempt']:$oldalarm['exempt'];
+				$save['exempt']           = isset($alarm['exempt'])         ? $alarm['exempt']:$oldalarm['exempt'];
+				$save['external_id']      = isset($alarm['external_id'])    ? $alarm['external_id']:$oldalarm['external_id'];
+				$save['notes']            = isset($alarm['notes'])          ? $alarm['notes']:$oldalarm['notes'];
 				$alarm = array();
 
 				/* unset non used variables */
@@ -6857,6 +7809,7 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 				unset($save['expression_id']);
 			}
 
+			// Colunns that always follow the template
 			foreach ($columns as $column) {
 				switch($column) {
 				case 'id':
@@ -6884,6 +7837,7 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 						input_validate_input_number($alarm[$column]);
 						$save[$column] = $alarm[$column];
 					}
+
 					break;
 				case 'name':
 				case 'base_time_display':
@@ -6893,10 +7847,14 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 				case 'trigger_cmd_norm':
 				case 'notify_extra':
 				case 'email_body':
+				case 'format_file':
 				case 'email_subject':
+				case 'external_id':
+				case 'notes':
 					if (isset($alarm[$column])) {
 						$save[$column] = $alarm[$column];
 					}
+
 					break;
 				case 'notify_users':
 				case 'req_ack':
@@ -6907,6 +7865,7 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 					} else {
 						$save[$column] = '';
 					}
+
 					break;
 				case 'syslog_enabled':
 				case 'cmd_retrigger_enabled':
@@ -6917,6 +7876,7 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 							$save[$column] = '';
 						}
 					}
+
 					break;
 				case 'notify_cluster_admin':
 					if (isset($alarm['notify_cluster_admin']) && $alarm['notify_cluster_admin'] == 'on') {
@@ -6924,17 +7884,18 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 					} else {
 						$save['notify_cluster_admin'] = 0;
 					}
-					break;
 
+					break;
 				}
 			}
 		}
 
 		if (isset($save['alarm_hi']) && isset($save['alarm_low']) &&
 			trim($save['alarm_hi']) != '' && trim($save['alarm_low']) != '' &&
-			round($save['alarm_low'], 4) >= round($save['alarm_hi'], 4)) {
+			round($save['alarm_low'], 2) >= round($save['alarm_hi'], 2)) {
 
 			raise_message('gridalarms_alarm_hilo_imp');
+
 			if (!empty($alarm['id'])) {
 				header('Location: gridalarms_alarm_edit.php?header=false&tab=' . $alarm['tab'] . '&id=' . $alarm['id']);
 			} else {
@@ -6968,9 +7929,9 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 			}
 		}
 
-		$save ['trigger_cmd_high'] 	= str_replace('"','\'', $save ['trigger_cmd_high']);
-		$save ['trigger_cmd_low'] 	= str_replace('"','\'', $save ['trigger_cmd_low']);
-		$save ['trigger_cmd_norm'] 	= str_replace('"','\'', $save ['trigger_cmd_norm']);
+		$save['trigger_cmd_high'] 	= str_replace('"','\'', $save['trigger_cmd_high']);
+		$save['trigger_cmd_low'] 	= str_replace('"','\'', $save['trigger_cmd_low']);
+		$save['trigger_cmd_norm'] 	= str_replace('"','\'', $save['trigger_cmd_norm']);
 
 		$id = sql_save($save , 'gridalarms_alarm');
 
@@ -7118,11 +8079,13 @@ function push_out_template_to_alarm($alarm, $template_id = 0, $repush = false) {
 }
 
 /**
- * $alarm                   - POST value when creating a alert
- * return value             - = 1, do the title replacement successfully,
-                              = -1, failed to do the title replacement.
+ * Replaces the title from an alarms components
+ *
+ * @param  array    $alarm the alarm
+ *
+ * @return bool|int 1 - title replacement successful, -1 - failed to do the title replacement.
  */
-function do_title_replacement(&$alarm) {
+function do_title_replacement(array &$alarm) : bool|int {
 	$title     = $alarm['name'];
 	$ret_title = '';
 
@@ -7161,9 +8124,7 @@ function do_title_replacement(&$alarm) {
 			if ($input_names[$m2]) {
 				$ret_title = str_replace('|input_' . $m2 . '|', "'" . $input_names[$m2] . "'", $ret_title);
 			} else {
-				raise_message ('gridalarms_title_replacement_failure', 
-					__('Alert name has unused custom data input ' . '|input_' . $m2 . '|, please remove from alert name.'),
-					MESSAGE_LEVEL_WARN);
+				raise_message('gridalarms_input_' . $m2, __esc('The Input Variable %s was in the Alert Name, but is not defined.  Please adjust your Alert Name.', $m2, 'gridalarms'), MESSAGE_LEVEL_WARN);
 			}
 		}
 	}
@@ -7173,12 +8134,15 @@ function do_title_replacement(&$alarm) {
 	return true;
 }
 
-/** returns the current unique hash for a alert template
- * @arg $id					- (int) the ID of the alert template to return a hash for
- * @arg $sub_type			- (optional) return the hash for a particlar sub-type of this type
- * @returns 				- a 128-bit, hexadecimal hash
+/**
+ * returns the current unique hash for a alert template
+ *
+ * @param  int    $id the ID of the alert template to return a hash for
+ * @param  string $sub_type the hash for a particlar sub-type of this type
+ *
+ * @return string the hash of the template
  */
-function get_hash_alert_template($id, $sub_type = 'alert_template') {
+function get_hash_alert_template(int $id, string $sub_type = 'alert_template') : string {
 	if (!empty($id)) {
 		if ($sub_type == 'alert_template') {
 			$hash = db_fetch_cell_prepared('SELECT hash
@@ -7220,7 +8184,7 @@ function get_hash_alert_template($id, $sub_type = 'alert_template') {
 	return generate_hash();
 }
 
-function check_gridalarms_db_upgrade() {
+function check_gridalarms_db_upgrade() : void {
 	if (read_config_option('gridalarms_db_upgrade', true) == '1') {
 		unset_request_var('drp_action');
 		unset_request_var('action');
@@ -7230,7 +8194,7 @@ function check_gridalarms_db_upgrade() {
 /* gridalarms_save_button - takes a form name and encode fields array and submits the form with the
 	selected form fields base64 encoded
 */
-function gridalarms_save_button($form_name, $encode_fields) {
+function gridalarms_save_button(string $form_name, bool $encode_fields) : void {
 	?>
 	<table class='cactiTable'>
 		<tr>
@@ -7299,7 +8263,7 @@ function gridalarms_save_button($form_name, $encode_fields) {
 	<?php
 }
 
-function gridalarms_do_import($xml_file) {
+function gridalarms_do_import(string $xml_file) : int {
     $fp = fopen($xml_file, 'r');
     $xml_data = fread($fp, filesize($xml_file));
     fclose($fp);
@@ -7312,13 +8276,15 @@ function gridalarms_do_import($xml_file) {
     $ret = check_import_xml_gridalarms_template($xml_data, $dup_alarm_array);
 
     if ($ret <0) {                                   //show error message
-        $debug_data=-1;
+        $debug_data = -1;
     } elseif ($ret == 0) {                          // no duplicate alert hash code, do the import
         import_xml_gridalarms_template($xml_data);
-        $debug_data=0;
+
+        $debug_data = 0;
     } else {
         import_xml_gridalarms_template($xml_data);
-        $debug_data=1;
+
+        $debug_data = 1;
     }
 
     return $debug_data;
@@ -7327,7 +8293,7 @@ function gridalarms_do_import($xml_file) {
 /**
  * call back function to print column options
  */
-function getcolumns() {
+function getcolumns() : void {
 	$db_columns = array();
 
 	if (isset_request_var('db_table')) {
@@ -7346,7 +8312,7 @@ function getcolumns() {
 /**
  * Callback function to return the tables base on the type selected
  */
-function gettables() {
+function gettables() : void {
 	$db_tables = array();
 
 	if (isset_request_var('type')) {

--- a/cacti/plugins/gridalarms/poller_gridalarms.php
+++ b/cacti/plugins/gridalarms/poller_gridalarms.php
@@ -3,7 +3,7 @@
 // $Id$
 /*
  +-------------------------------------------------------------------------+
- | Copyright IBM Corp. 2006, 2023                                          |
+ | Copyright IBM Corp. 2006, 2025                                          |
  |                                                                         |
  | Licensed under the Apache License, Version 2.0 (the "License");         |
  | you may not use this file except in compliance with the License.        |
@@ -19,10 +19,78 @@
  +-------------------------------------------------------------------------+
 */
 
+if (function_exists('pcntl_async_signals')) {
+	pcntl_async_signals(true);
+} else {
+	declare(ticks = 100);
+}
+
+ini_set('output_buffering', 'Off');
+
 include(dirname(__FILE__) . '/../../include/cli_check.php');
 include_once($config['base_path'] . '/plugins/gridalarms/lib/gridalarms_functions.php');
+include_once($config['base_path'] . '/plugins/gridalarms/setup.php');
 include_once($config['base_path'] . '/plugins/grid/lib/grid_functions.php');
 include_once($config['base_path'] . '/lib/rtm_functions.php');
+
+/**
+ * sig_handler - provides a generic means to catch exceptions to the Cacti log.
+ *
+ * @param int $signo the signal that was thrown by the interface.
+ *
+ * @return void
+ */
+function sig_handler($signo) {
+	global $task_id, $main;
+
+	switch ($signo) {
+		case SIGTERM:
+		case SIGINT:
+			if (!$main) {
+				$pids = array_rekey(db_fetch_assoc_prepared("SELECT pid
+					FROM grid_processes
+					WHERE taskid = ?
+					AND taskname='GRIDALARMS'",
+					array($task_id)), 'pid', 'pid');
+
+				if (cacti_sizeof($pids)) {
+					foreach($pids as $pid) {
+						posix_kill($pid, SIGTERM);
+					}
+				}
+
+				clearTask($task_id, getmypid());
+
+				sleep(5);
+
+				db_execute_prepared("DELETE
+					FROM grid_processes
+					WHERE taskid = ?
+					AND taskname='GRIDALARMS'",
+					array($task_id));
+			} else {
+				$pids = array_rekey(
+					db_fetch_assoc("SELECT pid
+						FROM grid_processes
+						WHERE taskname = 'GRIDALARMS'
+						AND taskid = 0"),
+					'pid', 'pid'
+				);
+
+				if (cacti_sizeof($pids)) {
+					foreach($pids as $pid) {
+						posix_kill($pid, SIGTERM);
+					}
+				}
+
+				clearTask($task_id, getmypid());
+			}
+
+			exit(0);
+		default:
+			/* ignore all other signals */
+	}
+}
 
 /* get the gridalarms polling cycle */
 ini_set('max_execution_time', '0');
@@ -32,111 +100,280 @@ ini_set('memory_limit', '-1');
 $parms = $_SERVER['argv'];
 array_shift($parms);
 
-global $config, $debug;
+global $config, $debug, $force, $debug, $task_id, $main;
 
-$debug          = FALSE;
-$forcerun       = FALSE;
-$forcerun_maint = FALSE;
+$debug       = false;
+$force       = false;
+$force_maint = false;
+$task_id     = -1;
+$main        = false;
 
-foreach($parms as $parameter) {
-	if (strpos($parameter, '=')) {
-		list($arg, $value) = explode('=', $parameter);
-	} else {
-		$arg = $parameter;
-		$value = '';
+if (cacti_sizeof($parms)) {
+	foreach($parms as $parameter) {
+		if (strpos($parameter, '=')) {
+			list($arg, $value) = explode('=', $parameter);
+		} else {
+			$arg = $parameter;
+			$value = '';
+		}
+
+		switch ($arg) {
+		case '-d':
+		case '--debug':
+			$debug = true;
+			break;
+		case '-M':
+		case '--main':
+			$main = true;
+			break;
+		case '--alarm-id':
+			$task_id = $value;
+			break;
+		case '-fr':
+			$force = true;
+			break;
+		case '-fm':
+			$force_maint = true;
+			break;
+		case '-v':
+		case '-V':
+		case '--version':
+			display_version();
+			exit(0);
+		case '-h':
+		case '-H':
+		case '--help':
+			display_help();
+			exit(0);
+		default:
+			print 'ERROR: Invalid Parameter ' . $parameter . PHP_EOL . PHP_EOL;
+			display_help();
+			exit(1);
+		}
+	}
+}
+
+if (read_config_option('thold_disable_all') == 'on') {
+	gridalarms_debug('WARNING: All Alerting is disabled.  Exiting.');
+	cacti_log('WARNING: All Alerting and Thrsholding is Disabled.  If this is not intended. Please correct at Console > Configuration > Settings > Alerting/Thold', false, 'GRID');
+	exit(0);
+}
+
+/* install signal handlers for UNIX only */
+if (function_exists('pcntl_signal')) {
+	pcntl_signal(SIGTERM, 'sig_handler');
+	pcntl_signal(SIGINT, 'sig_handler');
+}
+
+/* Let's ensure that we were called correctly */
+if (!$main) {
+	if ($task_id == -1) {
+		print "FATAL: You must specify -M to Start the Master Control Process, or the Alarm ID using --alarm-id" . PHP_EOL;
+		exit(1);
 	}
 
-	switch ($arg) {
-	case '-d':
-	case '--debug':
-		$debug = TRUE;
-		break;
-	case '-fr':
-		$forcerun = TRUE;
-		break;
-	case '-fm':
-		$forcerun_maint = TRUE;
-		break;
-	case '-h':
-	case '-v':
-	case '-V':
-	case '--version':
-	case '--help':
-		display_help();
-		exit;
-	default:
-		print 'ERROR: Invalid Parameter ' . $parameter . PHP_EOL . PHP_EOL;
-		display_help();
-		exit;
+	/* perform interim upgrade if required */
+	$cur_version = get_gridalarms_version();
+	$db_version  = db_fetch_cell_prepared('SELECT version FROM plugin_config WHERE directory = ?', array('gridalarms'));
+
+	if ($cur_version != $db_version) {
+		cacti_log("About to try an upgrade from '$db_version' to '$cur_version'", true, 'UPGRADE');
+
+		plugin_gridalarms_install(true);
 	}
 }
 
 // if db alarm upgrade process is running, do not run alarm check
-if (read_config_option('gridalarms_db_upgrade',TRUE) == '1') {
-	gridalarms_debug('DB alarm data upgrade in progress, will not run alarm check.');
-} else {
-	gridalarms_debug('NOTE   - About to enter gridalarms poller processing');
+if ($main) {
+	$start  = microtime(true);
+	$alarms = 0;
 
-	/* obtain the polleri interval if the user is using that Cacti mod */
-	$poller_interval = read_config_option('poller_interval');
-	if (empty($poller_interval)) {
-		$poller_interval = 300;
-	}
+	if (read_config_option('gridalarms_db_upgrade', true) == '1') {
+		gridalarms_debug('DB alarm data upgrade in progress, will not run alarm check.');
+	} else {
+		gridalarms_debug('NOTE   - About to enter gridalarms poller processing');
 
-	/* find out when it's time to perform maintenance */
-	$current_time = time();
-
-	$database_maint_time = strtotime('12:00am');
-	if ($database_maint_time < $current_time){
-		if ($current_time - $poller_interval < $database_maint_time){
-			$next_db_maint_time = $current_time;
-		}else{
-			$next_db_maint_time = $database_maint_time + 3600*24;
+		/* obtain the polleri interval if the user is using that Cacti mod */
+		$poller_interval = read_config_option('poller_interval');
+		if (empty($poller_interval)) {
+			$poller_interval = 300;
 		}
-	}else{
-		$next_db_maint_time = $database_maint_time;
+
+		/* find out when it's time to perform maintenance */
+		$current_time = time();
+
+		$database_maint_time = strtotime('12:00am');
+		if ($database_maint_time < $current_time) {
+			if ($current_time - $poller_interval < $database_maint_time) {
+				$next_db_maint_time = $current_time;
+			} else {
+				$next_db_maint_time = $database_maint_time + 3600*24;
+			}
+		} else {
+			$next_db_maint_time = $database_maint_time;
+		}
+
+		$time_till_next_db_maint = $next_db_maint_time - $current_time;
+		if (($time_till_next_db_maint <= 0) || ($force_maint)) {
+			$run_maint = true;
+			gridalarms_debug('The next gridalerts database maintenance is NOW');
+		} else {
+			$run_maint = false;
+			gridalarms_debug('The next gridalerts database maintenance is "'. date('Y-m-d G:i:s', $next_db_maint_time) . '"');
+		}
+
+		gridalarms_debug('START  - gridalarms Polling Process');
+
+		if (detect_and_correct_running_processes(0, 'GRIDALERTSPOLLER', $poller_interval*3) || $force) {
+			db_execute_prepared('REPLACE INTO settings
+				(name, value) VALUES
+				("gridalarms_last_run_time", ?)',
+				array(date('Y-m-d G:i:s', $current_time)));
+
+			/* process alarms */
+			gridalarms_debug('START  - Alerts Poller');
+			$alarms = gridalarms_alarm_parallel_poller();
+			gridalarms_debug('FINISH - Alerts Poller');
+			remove_process_entry(0, 'GRIDALERTSPOLLER');
+		}
+
+		if ($run_maint || $force_maint) {
+			gridalarms_debug('START - Alerts Log Cleanup');
+			gridalarms_alarm_log_cleanup();
+			gridalarms_debug('FINISH - Alerts Log Cleanup');
+		}
 	}
 
-	$time_till_next_db_maint = $next_db_maint_time - $current_time;
-	if (($time_till_next_db_maint <= 0) || ($forcerun_maint)) {
-		$run_maint = TRUE;
-		gridalarms_debug('The next gridalarms database maintenance is NOW');
-	}else{
-		$run_maint = FALSE;
-		gridalarms_debug('The next gridalarms database maintenance is "'. date('Y-m-d G:i:s', $next_db_maint_time) . '"');
+	$end = microtime(true);
+
+	$threads = read_config_option('gridalarm_parallel');
+
+	/* log statistics */
+	$gridalarms_alarm_stats = sprintf('Time:%01.4f Processes:%s Alerts:%s', $end - $start, $threads, $alarms);
+
+	cacti_log('GRIDALERTS STATS: ' . $gridalarms_alarm_stats, false, 'SYSTEM');
+
+	set_config_option('stats_gridalarms_alarm', $gridalarms_alarm_stats);
+} else {
+	$alarm = db_fetch_row_prepared('SELECT *
+		FROM gridalarms_alarm
+		WHERE id = ?',
+		array($task_id));
+
+	if (cacti_sizeof($alarm)) {
+		registerTask($task_id, getmypid());
+		gridalarms_check_alarm($alarm);
+		endTask($task_id, getmypid());
+	}
+}
+
+function gridalarms_alarm_parallel_poller() {
+	global $config, $debug, $force;
+
+	$alarms = db_fetch_assoc('SELECT *
+		FROM gridalarms_alarm
+		WHERE alarm_enabled = "on"
+		AND frequency > 0');
+
+	$total_alarms = cacti_sizeof($alarms);
+	$threads      = read_config_option('gridalarm_parallel');
+
+	gridalarms_debug("START  - Processing $total_alarms Alerts");
+
+	api_plugin_hook_function('gridalarms_reset_hostsalarm');
+
+	if (cacti_sizeof($alarms)) {
+		while (true) {
+			$running = runningTasks();
+
+			foreach ($alarms as $index => $alarm) {
+				if ($running < $threads) {
+					exec_background(read_config_option('path_php_binary'), '-q ' . read_config_option('path_webroot') . '/plugins/gridalarms/poller_gridalarms.php --alarm-id=' . $alarm['id'] . ($force ? ' -fr':'') . ($debug ? ' --debug':''));
+					$running++;
+
+					unset($alarms[$index]);
+				}
+			}
+
+			usleep(500000);
+
+			if (!cacti_sizeof($alarms) && $running == 0) {
+				break;
+			}
+		}
 	}
 
-	gridalarms_debug('START  - gridalarms Polling Process');
-	if (detect_and_correct_running_processes(0, 'GRIDALERTSPOLLER', $poller_interval*3)) {
-		db_execute_prepared('REPLACE INTO settings
-			(name, value) VALUES
-			("gridalarms_last_run_time", ?)',
-			array(date('Y-m-d G:i:s', $current_time)));
+	api_plugin_hook_function('gridalarms_delete_hostsalarm');
+	gridalarms_debug("FINISH - Processed $total_alarms Alerts");
 
-		/* process alarms */
-		gridalarms_debug('START  - Alerts Poller');
-		gridalarms_alarm_poller();
-		gridalarms_debug('FINISH - Alerts Poller');
-		remove_process_entry(0, 'GRIDALERTSPOLLER');
-	}
+	return $total_alarms;
+}
 
-	if ($run_maint || $forcerun_maint) {
-		gridalarms_debug('START - Alerts Log Cleanup');
-		gridalarms_alarm_log_cleanup();
-		gridalarms_debug('FINISH - Alerts Log Cleanup');
-	}
+/**
+ * display_version - Display useful version information.
+ */
+function display_version() {
+	print 'Grid Alerts Poller Process ' . read_config_option('gridalarms_db_version') . PHP_EOL;
+	print html_entity_decode('&#169;',ENT_NOQUOTES,'UTF-8').' Copyright International Business Machines Corp, ' . read_config_option('grid_copyright_year') . PHP_EOL . PHP_EOL;
 }
 
 /*	display_help - displays the usage of the function */
 function display_help () {
 	global $config;
 
-	print 'Grid Alerts Poller Process ' . read_config_option('gridalarms_db_version') . "\n";
-	print html_entity_decode('&#169;',ENT_NOQUOTES,'UTF-8').' Copyright International Business Machines Corp, ' . read_config_option('grid_copyright_year') . ".\n\n";
-	print "usage: poller_gridalarms.php [-fr] [-fm] [-d | --debug]\n\n";
-	print "-fr              - Force the interval process.  Used in conjunction with -fm\n";
-	print "-fm              - Force the maintenance process\n";
-	print "-d | --debug     - Display verbose output during execution\n";
-	print "-v -V --version  - Display this help message\n";
-	print "-h --help        - Display this help message\n";
+	display_version();
+
+	print "usage: poller_gridalarms.php [-M] [-fr] [-fm] [--debug] | [--alarm-id=N] [--debug]" . PHP_EOL . PHP_EOL;
+	print "-M               - Start the main poller process" . PHP_EOL;
+	print "--alarm-id       - Collect check this specific alarm-id" . PHP_EOL;
+	print "-fr              - Force the interval process.  Used in conjunction with -fm" . PHP_EOL;
+	print "-fm              - Force the maintenance process" . PHP_EOL;
+	print "-d | --debug     - Display verbose output during execution" . PHP_EOL;
 }
+
+function isProcessRunning($pid) {
+    return posix_kill($pid, 0);
+}
+
+function killProcess($pid) {
+    return posix_kill($pid, SIGTERM);
+}
+
+function runningTasks() {
+	return db_fetch_cell("SELECT COUNT(*)
+		FROM grid_processes
+		WHERE taskname = 'GRIDALARMS'
+		AND taskid > 0");
+}
+
+function registerTask($task_id, $pid) {
+	db_execute_prepared("REPLACE INTO grid_processes
+        (pid, taskname, taskid, heartbeat)
+        VALUES (?, ?, ?, NOW())",
+        array($pid, 'GRIDALARMS', $task_id));
+}
+
+function endTask($task_id, $pid) {
+	db_execute_prepared("DELETE FROM grid_processes
+        WHERE pid = ?
+		AND taskname = 'GRIDALARMS'
+        AND taskid = ?",
+        array($pid, $task_id));
+}
+
+function clearTask($task_id, $pid) {
+	db_execute_prepared("DELETE
+		FROM grid_processes
+		WHERE pid = ?
+		AND taskname = 'GRIDALARMS'
+		AND taskid = ?",
+		array($pid, $task_id));
+}
+
+function clearAllTasks($task_id) {
+	db_execute_prepared("DELETE FROM grid_processes
+		WHERE taskid = ?
+		AND taskname = 'GRIDALARMS'",
+		array($task_id));
+}
+

--- a/cacti/plugins/gridalarms/setup.php
+++ b/cacti/plugins/gridalarms/setup.php
@@ -2,7 +2,7 @@
 // $Id$
 /*
  +-------------------------------------------------------------------------+
- | Copyright IBM Corp. 2006, 2024                                          |
+ | Copyright IBM Corp. 2006, 2025                                          |
  |                                                                         |
  | Licensed under the Apache License, Version 2.0 (the "License");         |
  | you may not use this file except in compliance with the License.        |
@@ -76,12 +76,12 @@ function plugin_gridalarms_install($upgrade = false) {
 	// Remove/Disable cluster related alarms
 	api_plugin_register_hook('gridalarms', 'grid_cluster_remove', 'gridalarms_grid_cluster_remove', 'setup.php');
 
-
 	if ($upgrade) {
-        plugin_gridalarms_upgrade();
-        if (api_plugin_is_enabled('gridalarms')) {
-            api_plugin_enable_hooks('gridalarms');
-        }
+		plugin_gridalarms_upgrade();
+
+		if (api_plugin_is_enabled('gridalarms')) {
+			api_plugin_enable_hooks('gridalarms');
+		}
 	} else {
 		include_once($config['base_path'] . '/plugins/gridalarms/includes/database.php');
 
@@ -158,7 +158,7 @@ function gridalarms_rtm_landing_page() {
 
 function gridalarms_bottom_footer() {
 	if (preg_match('(gridalarms|grid_alarmdb)', basename($_SERVER['SCRIPT_NAME']))) {
-		echo "<div id='gridalarms_dialog' style='display:none;'></div>\n";
+		print "<div id='gridalarms_dialog' style='display:none;'></div>\n";
 	}
 }
 
@@ -167,7 +167,7 @@ function gridalarms_page_head() {
 
 	print "<link href='" . $config['url_path'] . "plugins/gridalarms/includes/main.css' type='text/css' rel='stylesheet'>";
 	print get_md5_include_js('plugins/gridalarms/includes/common.js');
-	if(strstr($_SERVER['SCRIPT_NAME'], 'plugins' . DIRECTORY_SEPARATOR . 'gridalarms' . DIRECTORY_SEPARATOR) === false)
+	if (strstr($_SERVER['SCRIPT_NAME'], 'plugins' . DIRECTORY_SEPARATOR . 'gridalarms' . DIRECTORY_SEPARATOR) === false)
 		return;
 }
 
@@ -184,20 +184,31 @@ function plugin_gridalarms_upgrade() {
 	include_once(dirname(__FILE__) . '/includes/database.php');
 
 	$gridalarms_version = read_config_option('gridalarms_version');
-	if(!empty($gridalarms_version)){
-		$gridalarms_version = db_fetch_cell('SELECT version FROM plugin_config WHERE directory="gridalarms"');
+	if (!empty($gridalarms_version)) {
+		$gridalarms_version = db_fetch_cell('SELECT version FROM plugin_config WHERE directory = "gridalarms"');
 	}
 
 	$gridalarms_current_version = get_gridalarms_version();
 
 	gridalarms_setup_new_tables();
-	//From Pre-9.1 to 9.1, upgrade process is background
+
+	/* from Pre-9.1 to 9.1, upgrade process is background */
 	if (isset($gridalarms_version)) {
 		rtm_plugin_upgrade_ga($gridalarms_version, $gridalarms_current_version, 'gridalarms');
 	}
+
+	db_execute_prepared('UPDATE plugin_realms
+		SET file = ?
+		WHERE file LIKE "%gridalarms_alarm.php%"',
+		array('gridalarms_alarm.php,gridalarms_templates.php,gridalarms_alarm_edit.php,gridalarms_template_edit.php'));
+
+	db_execute_prepared('UPDATE plugin_config
+		SET version = ?
+		WHERE directory = ?',
+		array($gridalarms_current_version, 'gridalarms'));
 }
 
-function plugin_gridalarms_uninstall(){
+function plugin_gridalarms_uninstall() {
 	return true;
 }
 
@@ -211,7 +222,8 @@ function gridalarms_poller_bottom() {
 	global $config;
 
 	$command_string = read_config_option('path_php_binary');
-	$extra_args = '-q ' . $config['base_path'] . '/plugins/gridalarms/poller_gridalarms.php';
+	$extra_args = '-q ' . $config['base_path'] . '/plugins/gridalarms/poller_gridalarms.php -M';
+
 	exec_background($command_string, $extra_args);
 
 	return true;
@@ -438,7 +450,7 @@ function gridalarms_draw_navigation_text ($nav) {
 	return $nav;
 }
 
-function gridalarms_grid_tab_down($pages_grid_tab_down){
+function gridalarms_grid_tab_down($pages_grid_tab_down) {
 	$gridalarms_pages_grid_tab_down=array(
 		'grid_alarmdb.php' => ''
 		);
@@ -477,7 +489,7 @@ function gridalarms_grid_menu($grid_menu = array()) {
  * @deprecated 10.2.0.1, prefer to use get_gridalarms_version or plugin_gridalarms_version
  * @return array include version, author,...
  */
-function gridalarms_version(){
+function gridalarms_version() {
 	return plugin_gridalarms_version();
 }
 
@@ -487,24 +499,26 @@ function gridalarms_version(){
  */
 function get_gridalarms_version() {
 	$info = plugin_gridalarms_version();
-	if(!empty($info) && isset($info['version'])){
+
+	if (!empty($info) && isset($info['version'])) {
 		return $info['version'];
 	}
+
 	return RTM_VERSION;
 }
 
-function gridalarms_grid_cluster_remove($cluster){
+function gridalarms_grid_cluster_remove($cluster) {
 	global $config;
 
-	if (!isset($cluster) || !isset($cluster['clusterid']) || !isset($cluster['delete_type'])){
+	if (!isset($cluster) || !isset($cluster['clusterid']) || !isset($cluster['delete_type'])) {
 		return $cluster;
 	}
 
 	db_execute_prepared('UPDATE gridalarms_template SET clusterid=0 WHERE clusterid=?', array($cluster['clusterid']));
 
-	if ($cluster['delete_type'] == 1){
+	if ($cluster['delete_type'] == 1) {
 		db_execute_prepared('UPDATE gridalarms_alarm SET alarm_enabled="off" WHERE clusterid=?', array($cluster['clusterid']));
-	} else if ($cluster['delete_type'] == 2){
+	} else if ($cluster['delete_type'] == 2) {
 		include_once($config['base_path'] . '/plugins/gridalarms/lib/gridalarms_functions.php');
 
 		$alarms = db_fetch_assoc_prepared('SELECT *

--- a/cacti/plugins/gridalarms/upgrades/10_2_0_16.php
+++ b/cacti/plugins/gridalarms/upgrades/10_2_0_16.php
@@ -2,7 +2,7 @@
 // $Id$
 /*
  +-------------------------------------------------------------------------+
- | Copyright IBM Corp. 2025                                          |
+ | Copyright IBM Corp. 2006, 2025                                          |
  |                                                                         |
  | Licensed under the Apache License, Version 2.0 (the "License");         |
  | you may not use this file except in compliance with the License.        |
@@ -18,25 +18,173 @@
  +-------------------------------------------------------------------------+
 */
 
+include_once(__DIR__ . '/../../../include/global.php');
+
+upgrade_to_10_2_0_16();
+
 function upgrade_to_10_2_0_16() {
-	global $system_type, $config;
-	include_once(dirname(__FILE__) . '/../../../lib/rtm_db_upgrade.php');
-	include_once(dirname(__FILE__) . '/../../../lib/plugins.php');
+	global $config;
+
+	include_once($config['library_path'] . '/rtm_functions.php');
+	include_once($config['library_path'] . '/rtm_db_upgrade.php');
 	include_once(dirname(__FILE__) . '/../lib/gridalarms_functions.php');
 
 	cacti_log('NOTE: Upgrading gridalarms to v10.2.0.16 ...', true, 'UPGRADE');
 
 	db_execute("UPDATE gridalarms_template_expression SET sql_query = 'SELECT gj.clusterid, gc.clustername, jobid, indexid, submit_time, stat, user,
 		effectiveEligiblePendingTimeLimit, (CAST(pend_time AS SIGNED) - CAST(ineligiblePendingTime AS SIGNED)) AS EligiblePendingTime
-		FROM grid_jobs AS gj, grid_clusters AS gc \nWHERE gj.clusterid = gc.clusterid 
-		AND stat in (\'PEND\', \'USUSP\', \'PSUSP\', \'SSUSP\') AND effectiveEligiblePendingTimeLimit >0 
-		AND (CAST(pend_time AS SIGNED) - CAST(ineligiblePendingTime AS SIGNED)) > effectiveEligiblePendingTimeLimit \n\n' 
-		where id = 7");
+		FROM grid_jobs AS gj, grid_clusters AS gc \nWHERE gj.clusterid = gc.clusterid
+		AND stat in (\'PEND\', \'USUSP\', \'PSUSP\', \'SSUSP\') AND effectiveEligiblePendingTimeLimit >0
+		AND (CAST(pend_time AS SIGNED) - CAST(ineligiblePendingTime AS SIGNED)) > effectiveEligiblePendingTimeLimit \n\n'
+		WHERE id = 7");
 
-	db_execute("UPDATE gridalarms_expression SET sql_query = 'SELECT gj.clusterid, gc.clustername, jobid, indexid, submit_time, stat, user, 
+	db_execute("UPDATE gridalarms_expression SET sql_query = 'SELECT gj.clusterid, gc.clustername, jobid, indexid, submit_time, stat, user,
 		effectiveEligiblePendingTimeLimit, (CAST(pend_time AS SIGNED) - CAST(ineligiblePendingTime AS SIGNED)) AS EligiblePendingTime
-		FROM grid_jobs AS gj, grid_clusters AS gc \nWHERE gj.clusterid = gc.clusterid 
-		AND stat in (\'PEND\', \'USUSP\', \'PSUSP\', \'SSUSP\') AND effectiveEligiblePendingTimeLimit >0 
-		AND (CAST(pend_time AS SIGNED) - CAST(ineligiblePendingTime AS SIGNED)) > effectiveEligiblePendingTimeLimit \n\n' 
-		where template_id = 7");
+		FROM grid_jobs AS gj, grid_clusters AS gc \nWHERE gj.clusterid = gc.clusterid
+		AND stat in (\'PEND\', \'USUSP\', \'PSUSP\', \'SSUSP\') AND effectiveEligiblePendingTimeLimit >0
+		AND (CAST(pend_time AS SIGNED) - CAST(ineligiblePendingTime AS SIGNED)) > effectiveEligiblePendingTimeLimit \n\n'
+		WHERE template_id = 7");
+
+	db_add_column('gridalarms_alarm_layout', array(
+		'name' => 'type',
+		'type' => 'varchar(10)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'sortdirection')
+	);
+
+	db_add_column('gridalarms_alarm_layout', array(
+		'name' => 'units',
+		'type' => 'varchar(10)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'type')
+	);
+
+	db_add_column('gridalarms_alarm_layout', array(
+		'name' => 'align',
+		'type' => 'varchar(10)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'units')
+	);
+
+	db_add_column('gridalarms_alarm_layout', array(
+		'name' => 'digits',
+		'type' => 'tinyint(4)',
+		'NULL' => false,
+		'default' => '-1',
+		'after' => 'align')
+	);
+
+	db_add_column('gridalarms_alarm_layout', array(
+		'name' => 'autoscale',
+		'type' => 'tinyint(4)',
+		'NULL' => false,
+		'default' => '0',
+		'after' => 'digits')
+	);
+
+	db_add_column('gridalarms_template_layout', array(
+		'name' => 'type',
+		'type' => 'varchar(10)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'sortdirection')
+	);
+
+	db_add_column('gridalarms_template_layout', array(
+		'name' => 'units',
+		'type' => 'varchar(10)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'type')
+	);
+
+	db_add_column('gridalarms_template_layout', array(
+		'name' => 'align',
+		'type' => 'varchar(10)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'units')
+	);
+
+	db_add_column('gridalarms_template_layout', array(
+		'name' => 'digits',
+		'type' => 'tinyint(4)',
+		'NULL' => false,
+		'default' => '-1',
+		'after' => 'align')
+	);
+
+	db_add_column('gridalarms_template_layout', array(
+		'name' => 'autoscale',
+		'type' => 'tinyint(4)',
+		'NULL' => false,
+		'default' => '0',
+		'after' => 'digits')
+	);
+
+	db_add_column('gridalarms_alarm', array(
+		'name' => 'format_file',
+		'type' => 'varchar(255)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'email_subject')
+	);
+
+	db_add_column('gridalarms_template', array(
+		'name' => 'format_file',
+		'type' => 'varchar(255)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'email_subject')
+	);
+
+	db_add_column('gridalarms_alarm', array(
+		'name' => 'notes',
+		'type' => 'text',
+		'NULL' => true,
+		'after' => 'format_file')
+	);
+
+	db_add_column('gridalarms_template', array(
+		'name' => 'notes',
+		'type' => 'text',
+		'NULL' => true,
+		'after' => 'format_file')
+	);
+
+	db_add_column('gridalarms_alarm', array(
+		'name' => 'external_id',
+		'type' => 'varchar(40)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'notes')
+	);
+
+	db_add_column('gridalarms_template', array(
+		'name' => 'external_id',
+		'type' => 'varchar(40)',
+		'NULL' => false,
+		'after' => 'notes')
+	);
+
+	db_add_column('gridalarms_expression', array(
+		'name' => 'column_data',
+		'type' => 'varchar(512)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'sql_query')
+	);
+
+	db_add_column('gridalarms_template_expression', array(
+		'name' => 'column_data',
+		'type' => 'varchar(512)',
+		'NULL' => false,
+		'default' => '',
+		'after' => 'sql_query')
+	);
+
+	return 0;
 }


### PR DESCRIPTION
Enhancements include:

* Parallel polling for large installs or long running queries
* Alert Column Types (string, date, numeric)
* Alert Column Alignment
* Drag and Drop Column Ordering
* Add Custom Format Files
* Consistent handling of --version --help on poller
* Disable polling when Alerting is disabled identical to thold
* Proper Signal Handling for poller termination
* Some PSR and PHPDoc blocking and typing
* Show actual preview of run script on edit page in script context
* Support Disabling Legacy Notification identical to thold
* Add External ID and Notes for downstream monitoring

Signed-off-by: Larry Adams <thewitness@cacti.net>